### PR TITLE
Add flow-defi and flow-tokenomics skills; patch existing skills for correctness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,12 +29,16 @@ plugins/
             plugin.json         # Plugin metadata (name, version, author, keywords)
         skills/
             cadence-lang/       # Cadence language fundamentals (14 references)
-            cadence-tokens/     # NFT/FT token development (2 references)
+            cadence-tokens/     # NFT/FT token development (3 references)
             cadence-defi-actions/ # DeFi Actions framework (5 references)
             cadence-audit/      # Security audit & review (2 references)
             cadence-scaffold/   # Code generation templates (3 references)
             flow-project-setup/ # Project config & deployment (2 references)
+            flow-cli/           # Flow CLI commands & scripts (4 references)
+            flow-react-sdk/     # React frontend on Flow (4 references)
             flow-dev-setup/     # Dev environment setup (8 references)
+            flow-defi/          # DeFi protocol architecture (4 references)
+            flow-tokenomics/    # Token design & launch strategy (5 references)
 README.md                       # Installation instructions and plugin catalog
 ```
 
@@ -52,6 +56,8 @@ When a developer asks for help, use this table to determine which skill(s) to ac
 | Build React frontend on Flow | `flow-react-sdk` | |
 | Set up a Flow project, configure flow.json, deploy | `flow-project-setup` | |
 | Install dev tools (Flow CLI, emulator, VS Code, EVM tooling) | `flow-dev-setup` | `flow-project-setup` |
+| Design or architect a DeFi protocol on Flow | `flow-defi` | `cadence-defi-actions` |
+| Design token economics for a Flow protocol | `flow-tokenomics` | `flow-defi`, `cadence-tokens` |
 
 ## Key Conventions
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then install individual plugins:
 
 | Plugin | Description | Skills | Category |
 |--------|-------------|--------|----------|
-| **flow-dev** | Flow blockchain development | `cadence-lang`, `cadence-tokens`, `cadence-defi-actions`, `cadence-audit`, `cadence-scaffold`, `flow-react-sdk`, `flow-project-setup`, `flow-dev-setup` | blockchain |
+| **flow-dev** | Flow blockchain development | `cadence-lang`, `cadence-tokens`, `cadence-defi-actions`, `cadence-audit`, `cadence-scaffold`, `flow-react-sdk`, `flow-project-setup`, `flow-cli`, `flow-dev-setup`, `flow-defi`, `flow-tokenomics` | blockchain |
 
 ### flow-dev
 
@@ -45,7 +45,10 @@ Skills for developing on the Flow blockchain:
 | `cadence-scaffold` | Interactive code generation: scaffold production-ready contracts, transactions, and DeFi transactions with proper security patterns |
 | `flow-react-sdk` | React frontend development: FlowProvider setup, Cadence hooks (query, mutate, auth, events), Cross-VM hooks (EVM bridging, batch transactions), UI components (Connect, TransactionButton, NftCard) |
 | `flow-project-setup` | Flow project configuration: flow.json setup, FCL frontend integration, CLI workflow, deployment, debugging, gas optimization, testnet validation |
+| `flow-cli` | Flow CLI reference: full command list, account management, query blockchain (accounts/blocks/events/transactions), Cadence script recipes, MCP server setup |
 | `flow-dev-setup` | Development environment setup: Flow CLI installation, emulator, VS Code extension, testing framework, dev wallet, frontend SDKs (FCL/React), EVM tooling (Hardhat/Foundry/Remix) |
+| `flow-defi` | Flow DeFi architecture: COAs, MEV-free EVM, cross-VM atomicity, lending health factor/kink models, AMM type selection, liquidity bootstrapping benchmarks, veFLOW, Merkl, ecosystem map |
+| `flow-tokenomics` | Token economics: Fisher Equation, Nash equilibrium, proven patterns (Real Yield/Buyback/veToken) with failure case studies, TGE 12-week playbook, DAO governance attack vectors, Howey Test, MiCA compliance |
 
 ## Repository Structure
 
@@ -78,9 +81,18 @@ plugins/
             flow-project-setup/
                 SKILL.md    # Project setup guide
                 references/ # 2 reference files
+            flow-cli/
+                SKILL.md    # CLI reference guide
+                references/ # 6 reference files
             flow-dev-setup/
                 SKILL.md    # Dev environment setup guide
                 references/ # 8 reference files
+            flow-defi/
+                SKILL.md    # DeFi architecture guide
+                references/ # 4 reference files
+            flow-tokenomics/
+                SKILL.md    # Tokenomics guide
+                references/ # 5 reference files
 ```
 
 ## Contributing

--- a/plugins/flow-dev/skills/cadence-audit/references/audit-checklist.md
+++ b/plugins/flow-dev/skills/cadence-audit/references/audit-checklist.md
@@ -18,6 +18,7 @@
 ### Capability Security
 - Are public capabilities issued without entitlements?
 - Are entitled capabilities stored privately (never published)?
+- Are pre-existing capabilities checked before issuance to avoid proliferation? (Principle of Least Authority: issue minimum entitlements needed)
 - Are controllers stored for later revocation?
 - Is `borrow()` used with optional handling (never force unwrap `!`)?
 
@@ -37,6 +38,14 @@
 ### Emergency Controls
 - Is there an option to disable critical functionality in emergencies?
 - Can admin pause/unpause the contract?
+
+### Transactions
+- Is transaction code reviewed with the same rigor as contracts?
+- Does `prepare` only access account storage and capabilities (no business logic)?
+- Is all business logic in `execute` (not `prepare`)?
+- Are requested entitlements minimal for the operation (Principle of Least Authority)?
+- Are `pre`/`post` conditions used where they add safety guarantees?
+- Does each `pre`/`post` condition evaluate to a single boolean expression (no side effects, no assignments, no control flow inside a condition)?
 
 ## Bug Detection
 

--- a/plugins/flow-dev/skills/cadence-defi-actions/references/safety-testing.md
+++ b/plugins/flow-dev/skills/cadence-defi-actions/references/safety-testing.md
@@ -10,7 +10,7 @@ import FungibleToken from 0x123  // ❌ COMPILE ERROR
 ```
 
 ### Transaction Layout Order
-Write blocks in this order for reviewability: `prepare` → `pre` → `post` → `execute`
+Write blocks in this order: `prepare` → `pre` → `execute` → `post`
 
 ### Single Expression in Pre/Post (BLOCKING)
 ```cadence
@@ -25,7 +25,7 @@ pre { let isValid = amount > 0.0; isValid: "msg" }
 For restaking: derive `expectedStakeIncrease` from connector quotes:
 ```cadence
 post {
-    self.pool.getUserInfo(address: self.userCertificateCap.address)!.stakingAmount
+    self.pool.getUserInfo(address: self.userCertificateCap.address)?.stakingAmount ?? 0.0
         >= self.startingStake + self.expectedStakeIncrease:
         "Restaked amount below expected"
 }

--- a/plugins/flow-dev/skills/cadence-defi-actions/references/workflows.md
+++ b/plugins/flow-dev/skills/cadence-defi-actions/references/workflows.md
@@ -63,7 +63,7 @@ transaction(pid: UInt64) {
 
     execute {
         let poolSink = IncrementFiStakingConnectors.PoolSink(
-            pid: pid, staker: self.userCertificateCap.address, uniqueID: nil
+            pid: pid, staker: self.userCertificateCap.address, uniqueID: operationID
         )
         let vault <- self.swapSource.withdrawAvailable(maxAmount: poolSink.minimumCapacity())
         poolSink.depositCapacity(from: &vault as auth(FungibleToken.Withdraw) &{FungibleToken.Vault})

--- a/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-defi.md
+++ b/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-defi.md
@@ -89,7 +89,8 @@ transaction(pid: UInt64) {
     }
 
     post {
-        self.pool.getUserInfo(address: self.userCertificateCap.address)!.stakingAmount
+        // Optional chaining avoids a panic if getUserInfo returns nil (safer than force-unwrap)
+        self.pool.getUserInfo(address: self.userCertificateCap.address)?.stakingAmount ?? 0.0
             >= self.startingStake + self.expectedStakeIncrease:
             "Restake below expected amount"
     }

--- a/plugins/flow-dev/skills/cadence-tokens/SKILL.md
+++ b/plugins/flow-dev/skills/cadence-tokens/SKILL.md
@@ -24,6 +24,7 @@ Build NFT and FT contracts that conform to Flow's standard interfaces for market
 |------|-----------|
 | NFT interface conformance, required functions, MetadataViews, paths, events | [nft-standards.md](references/nft-standards.md) |
 | Modular NFT design, trait systems, FT patterns, advanced architectures | [token-patterns.md](references/token-patterns.md) |
+| Advanced NFT: TraitModule full spec, lazy init ❌/✅, genetic systems, common mistakes | [nft-advanced.md](references/nft-advanced.md) |
 
 ## Companion Skills
 

--- a/plugins/flow-dev/skills/cadence-tokens/references/nft-advanced.md
+++ b/plugins/flow-dev/skills/cadence-tokens/references/nft-advanced.md
@@ -1,0 +1,264 @@
+# NFT Advanced Patterns
+
+Advanced patterns for NFTs with dynamic traits, evolution, genetic systems, and complex behaviors. For standard interface conformance and basic collection patterns, see `token-patterns.md`.
+
+## TraitModule Interface — Full Definition
+
+Each trait module is a separate contract implementing the `TraitModule` interface:
+
+```cadence
+// In TraitModule.cdc (shared interface contract)
+access(all) contract interface TraitModule {
+
+    access(all) resource interface Trait {
+        // Read current value
+        access(all) view fun getRawValue(): AnyStruct
+        access(all) view fun getValueAsString(): String
+        access(all) view fun getDisplayName(): String
+
+        // Check before evolving
+        access(all) view fun canEvolve(): Bool
+
+        // Accumulative evolution — called by core NFT contract
+        // access(all) required: called cross-contract from EvolvingNFT
+        // @discardableResult: callers may discard the return value
+        @discardableResult
+        access(all) fun evolveAccumulative(
+            seeds: {String: UInt64},
+            steps: UInt64,
+            nftOwner: Address?,
+            nftUUID: UInt64
+        ): AnyStruct?
+
+        // Internal update — access(all) required for cross-contract use
+        access(all) fun updateValue(newValue: AnyStruct)
+    }
+
+    // Factory functions — implemented by each module contract
+    access(all) fun createDefaultTrait(nftUUID: UInt64): @{Trait}
+    access(all) fun createTraitWithSeed(seed: UInt64, nftUUID: UInt64): @{Trait}
+    access(all) fun createChildTrait(
+        parent1Trait: &{Trait},
+        parent2Trait: &{Trait},
+        seed: UInt64,
+        nftUUID: UInt64
+    ): @{Trait}
+    access(all) fun createMitosisChild(
+        parentTrait: &{Trait},
+        seed: UInt64,
+        nftUUID: UInt64
+    ): @{Trait}
+}
+```
+
+---
+
+## Module Registry Pattern
+
+The core NFT contract maintains a registry mapping module type strings to their deployed contracts:
+
+```cadence
+// ✅ Module registry in core NFT contract
+access(all) contract EvolvingNFT: NonFungibleToken {
+
+    // Module type → (contract address, contract name)
+    access(self) var registeredModules: {String: Address}
+    access(self) var moduleContracts: {String: String}
+
+    // Ordered list — determines evolution processing order
+    access(self) var moduleOrder: [String]
+
+    // Admin-only registration
+    access(account) fun registerModule(
+        moduleType: String,
+        contractAddress: Address,
+        contractName: String
+    ) {
+        self.registeredModules[moduleType] = contractAddress
+        self.moduleContracts[moduleType] = contractName
+        if !self.moduleOrder.contains(moduleType) {
+            self.moduleOrder.append(moduleType)
+        }
+    }
+
+    // Public read — used by trait lazy init
+    access(all) view fun getModuleFactory(
+        moduleType: String
+    ): &{TraitModule}? {
+        if let address = self.registeredModules[moduleType],
+           let name = self.moduleContracts[moduleType] {
+            return getAccount(address).contracts.borrow<&{TraitModule}>(name: name)
+        }
+        return nil
+    }
+}
+```
+
+---
+
+## Lazy Trait Initialization — ❌ / ✅
+
+### ❌ Eager initialization wastes gas for unused traits
+```cadence
+// Bad: Creates all trait resources at mint time
+access(all) fun mint(): @NFT {
+    let nft <- create NFT(uuid: self.nextID)
+    // Force-creates every possible trait upfront
+    nft.traits["strength"] <-! StrengthModule.createDefaultTrait(nftUUID: nft.uuid)
+    nft.traits["speed"] <-! SpeedModule.createDefaultTrait(nftUUID: nft.uuid)
+    nft.traits["magic"] <-! MagicModule.createDefaultTrait(nftUUID: nft.uuid)
+    return <- nft
+}
+```
+
+### ✅ Lazy initialization — create only when accessed
+```cadence
+// Good: Trait created on first access
+access(contract) fun ensureTraitExists(traitType: String): Bool {
+    if self.traits.containsKey(traitType) { return true }
+    if let factory = EvolvingNFT.getModuleFactory(moduleType: traitType) {
+        let defaultTrait <- factory.createDefaultTrait(nftUUID: self.uuid)
+        let old <- self.traits.insert(key: traitType, <-defaultTrait)
+        destroy old  // destroy nil placeholder
+        return true
+    }
+    return false
+}
+
+// Caller pattern
+access(all) fun getTraitValue(traitType: String): AnyStruct? {
+    if self.ensureTraitExists(traitType: traitType) {
+        return self.traits[traitType]?.getRawValue()
+    }
+    return nil
+}
+```
+
+---
+
+## Module Ordering — Controls Evolution Sequence
+
+```cadence
+// ✅ Order matters: earlier modules can affect later ones
+// e.g., "strength" feeds into "combatPower" calculation
+
+access(all) fun evolve() {
+    let elapsed = getCurrentBlock().timestamp - self.lastEvolutionTimestamp
+    let steps = UInt64(elapsed / self.evolutionInterval)
+    if steps == 0 { return }
+
+    // Seeds derived from unpredictable state
+    let seeds: {String: UInt64} = {
+        "time": UInt64(getCurrentBlock().timestamp),
+        "height": getCurrentBlock().height,
+        "uuid": self.uuid
+    }
+
+    // Process in registered order — dependency-safe
+    for moduleType in EvolvingNFT.moduleOrder {
+        if self.ensureTraitExists(traitType: moduleType) {
+            self.traits[moduleType]?.evolveAccumulative(
+                seeds: seeds,
+                steps: steps,
+                nftOwner: self.owner?.address,
+                nftUUID: self.uuid
+            )
+        }
+    }
+
+    self.lastEvolutionTimestamp = getCurrentBlock().timestamp
+}
+```
+
+---
+
+## Genetic Systems
+
+### Dominance / Recessive in `createChildTrait`
+```cadence
+access(all) fun createChildTrait(
+    parent1Trait: &{TraitModule.Trait},
+    parent2Trait: &{TraitModule.Trait},
+    seed: UInt64,
+    nftUUID: UInt64
+): @{TraitModule.Trait} {
+    let p1 = parent1Trait.getRawValue() as? UInt64 ?? 0
+    let p2 = parent2Trait.getRawValue() as? UInt64 ?? 0
+
+    // Dominant allele wins; 25% chance of recessive expression
+    let isDominantExpressed = (seed % 4) != 0  // 75% dominant
+    let value = isDominantExpressed
+        ? (p1 > p2 ? p1 : p2)    // dominant = higher value
+        : (p1 < p2 ? p1 : p2)    // recessive = lower value
+
+    // Rare mutation (1 in 256)
+    let mutated = (seed % 256) == 0
+        ? value + (seed % 10) + 1  // small positive mutation
+        : value
+
+    return <- create Trait(value: mutated, nftUUID: nftUUID)
+}
+```
+
+### Averaging / Blending
+```cadence
+// For continuous traits (e.g., height, speed)
+let blended = (p1 + p2) / 2
+// Optional variance: ± (seed % varianceRange)
+let withVariance = blended + (seed % 5) - 2  // ±2 variance
+```
+
+---
+
+## Common Mistakes
+
+### ❌ Forgetting to destroy the old value in insert
+```cadence
+// Bad: resource leak if key already exists
+self.traits[traitType] = <-newTrait  // ❌ Can't assign resource this way
+self.traits.insert(key: traitType, <-newTrait)  // ❌ Old resource leaked if key exists
+```
+
+### ✅ Always capture and destroy the displaced value
+```cadence
+let old <- self.traits.insert(key: traitType, <-newTrait)
+destroy old  // Destroys nil (placeholder) or the previous trait resource
+```
+
+### ❌ Using block timestamp as sole randomness source
+```cadence
+// Bad: validators know block timestamp, predictable
+let seed = UInt64(getCurrentBlock().timestamp)
+```
+
+### ✅ Mix multiple entropy sources
+```cadence
+let seed = UInt64(getCurrentBlock().timestamp) ^ getCurrentBlock().height ^ self.uuid
+// For strong randomness, use Flow's VRF: RandomBeaconHistory contract
+```
+
+### ❌ Accessing all modules during a read (MetadataViews)
+```cadence
+// Bad: evolveAccumulative called in a view function via MetadataViews
+access(all) fun resolveView(_ view: Type): AnyStruct? {
+    if view == Type<MetadataViews.Traits>() {
+        self.evolve()  // ❌ State mutation in view context
+    }
+}
+```
+
+### ✅ Separate read from write
+```cadence
+// Traits view returns current stored values (no mutation)
+access(all) view fun resolveView(_ view: Type): AnyStruct? {
+    if view == Type<MetadataViews.Traits>() {
+        return self.buildTraitsView()  // pure read
+    }
+    return nil
+}
+
+// Evolution is a separate transaction
+access(all) fun evolve() { /* state mutation */ }
+```
+
+> **See also:** `token-patterns.md` for the full `TraitModule.Trait` interface definition, the core NFT resource structure, and FT patterns.

--- a/plugins/flow-dev/skills/cadence-tokens/references/token-patterns.md
+++ b/plugins/flow-dev/skills/cadence-tokens/references/token-patterns.md
@@ -57,9 +57,11 @@ Core contract hosts `reproduceSexual()` and `reproduceAsexual()` functions that 
 access(all) resource interface Trait {
     access(all) view fun getRawValue(): AnyStruct
     access(all) view fun getValueAsString(): String
-    access(contract) fun updateValue(newValue: AnyStruct)
+    access(all) fun updateValue(newValue: AnyStruct)
     access(all) view fun getDisplayName(): String
-    access(contract) fun evolveAccumulative(seeds: {String: UInt64}, steps: UInt64, nftOwner: Address?, nftUUID: UInt64): AnyStruct?
+    // @discardableResult: callers (e.g. EvolvingNFT) may discard the return value
+    @discardableResult
+    access(all) fun evolveAccumulative(seeds: {String: UInt64}, steps: UInt64, nftOwner: Address?, nftUUID: UInt64): AnyStruct?
     access(all) view fun canEvolve(): Bool
 }
 ```

--- a/plugins/flow-dev/skills/flow-cli/SKILL.md
+++ b/plugins/flow-dev/skills/flow-cli/SKILL.md
@@ -2,7 +2,7 @@
 name: flow-cli
 description: |
   Complete reference for the Flow CLI — the command-line tool for developing, testing, and deploying on the Flow blockchain. Covers project initialization, account management, contract deployment, transaction sending, script execution, dependency management, key generation, scheduled transactions, and emulator usage.
-  TRIGGER when: using the Flow CLI, running flow commands, "flow accounts get", "flow accounts create", "flow init", "flow project deploy", "flow scripts execute", "flow transactions send", "flow test", "flow emulator", "flow keys generate", "flow dependencies install", "flow schedule", "flow accounts fund", "deploy contract to testnet", "how to create a Flow account", "check account balance on Flow", "run cadence script", "send a transaction", "flow accounts add-contract", "flow accounts staking-info".
+  TRIGGER when: using the Flow CLI, running flow commands, "flow accounts get", "flow accounts create", "flow init", "flow project deploy", "flow scripts execute", "flow transactions send", "flow test", "flow emulator", "flow keys generate", "flow dependencies install", "flow accounts fund", "deploy contract to testnet", "how to create a Flow account", "check account balance on Flow", "run cadence script", "send a transaction", "flow accounts add-contract", "flow accounts staking-info".
   DO NOT TRIGGER when: writing Cadence contract code (use cadence-lang), building React frontends (use flow-react-sdk), composing DeFi transactions in Cadence (use cadence-defi-actions), auditing code (use cadence-audit).
 ---
 
@@ -23,9 +23,11 @@ flow test                # Run tests
 
 | Task | Reference |
 |------|-----------|
-| Full command list, global flags, output options | [commands-overview.md](references/commands-overview.md) |
+| Full command list, global flags, output options, MCP server | [commands-overview.md](references/commands-overview.md) |
 | Account commands: get, create, fund, staking, contracts | [accounts.md](references/accounts.md) |
 | Project commands: init, generate, deploy, test, deps, config | [project.md](references/project.md) |
+| Query blockchain: accounts, blocks, events, transactions, scripts | [query-blockchain.md](references/query-blockchain.md) |
+| Ready-to-use Cadence script recipes (balance, staking, NFT, EVM) | [cadence-scripts.md](references/cadence-scripts.md) |
 
 ## Key Principles
 

--- a/plugins/flow-dev/skills/flow-cli/references/cadence-scripts.md
+++ b/plugins/flow-dev/skills/flow-cli/references/cadence-scripts.md
@@ -1,0 +1,293 @@
+# Cadence Script Recipes
+
+Ready-to-use scripts for common Flow blockchain queries. Execute with:
+```bash
+flow scripts execute <script-file> [args] --network mainnet
+```
+
+---
+
+## Token Queries
+
+### Get FLOW Balance
+```cadence
+import "FungibleToken"
+import "FlowToken"
+
+access(all) fun main(address: Address): UFix64 {
+    let account = getAccount(address)
+    let vaultRef = account.capabilities
+        .borrow<&{FungibleToken.Balance}>(/public/flowTokenBalance)
+        ?? panic("Could not borrow FlowToken balance capability from \(address)")
+    return vaultRef.balance
+}
+```
+
+### Get FLOW Balance (Multiple Accounts)
+```cadence
+import "FungibleToken"
+import "FlowToken"
+
+access(all) fun main(addresses: [Address]): {Address: UFix64} {
+    let balances: {Address: UFix64} = {}
+    for address in addresses {
+        let account = getAccount(address)
+        if let vaultRef = account.capabilities
+            .borrow<&{FungibleToken.Balance}>(/public/flowTokenBalance) {
+            balances[address] = vaultRef.balance
+        } else {
+            balances[address] = 0.0
+        }
+    }
+    return balances
+}
+```
+
+### Get FT Total Supply
+```cadence
+import "FlowToken"
+
+access(all) fun main(): UFix64 {
+    return FlowToken.totalSupply
+}
+```
+
+### Check FT Receiver Capability
+```cadence
+import "FungibleToken"
+
+access(all) fun main(address: Address, publicPath: PublicPath): Bool {
+    let account = getAccount(address)
+    return account.capabilities
+        .borrow<&{FungibleToken.Receiver}>(publicPath) != nil
+}
+```
+
+---
+
+## Account & Storage Queries
+
+### Get Account Keys
+```cadence
+access(all) fun main(address: Address): [{String: AnyStruct}] {
+    let account = getAccount(address)
+    var keys: [{String: AnyStruct}] = []
+    var i = 0
+    while true {
+        if let key = account.keys.get(keyIndex: i) {
+            keys.append({
+                "index": i,
+                "weight": key.weight,
+                "hashAlgorithm": key.hashAlgorithm.rawValue,
+                "signatureAlgorithm": key.signatureAlgorithm.rawValue,
+                "isRevoked": key.isRevoked
+            })
+            i = i + 1
+        } else {
+            break
+        }
+    }
+    return keys
+}
+```
+
+### Get Deployed Contract Names
+```cadence
+access(all) fun main(address: Address): [String] {
+    return getAccount(address).contracts.names
+}
+```
+
+### Check Storage Capacity
+```cadence
+import "FlowStorageFees"
+
+access(all) fun main(address: Address): {String: UFix64} {
+    let account = getAccount(address)
+    let used = account.storage.used
+    let capacity = account.storage.capacity
+    return {
+        "used": UFix64(used),
+        "capacity": UFix64(capacity),
+        "available": UFix64(capacity) - UFix64(used)
+    }
+}
+```
+
+---
+
+## Epoch & Protocol Queries
+
+### Get Current Epoch Counter
+```cadence
+import "FlowEpoch"
+
+access(all) fun main(): UInt64 {
+    return FlowEpoch.currentEpochCounter
+}
+```
+
+### Get Epoch Metadata
+```cadence
+import "FlowEpoch"
+
+access(all) fun main(epochCounter: UInt64): FlowEpoch.EpochMetadata? {
+    return FlowEpoch.getEpochMetadata(epochCounter)
+}
+```
+
+### Get Current Block Info
+```cadence
+access(all) fun main(): {String: AnyStruct} {
+    let block = getCurrentBlock()
+    return {
+        "height": block.height,
+        "id": block.id,
+        "timestamp": block.timestamp
+    }
+}
+```
+
+---
+
+## Staking Queries
+
+### Get Node Info
+```cadence
+import "FlowIDTableStaking"
+
+access(all) fun main(nodeID: String): FlowIDTableStaking.NodeInfo? {
+    return FlowIDTableStaking.getNodeInfo(nodeID: nodeID)
+}
+```
+
+### Get All Node IDs
+```cadence
+import "FlowIDTableStaking"
+
+access(all) fun main(): [String] {
+    return FlowIDTableStaking.getNodeIDs()
+}
+```
+
+### Get Delegator Info
+```cadence
+import "FlowIDTableStaking"
+
+access(all) fun main(nodeID: String, delegatorID: UInt32): FlowIDTableStaking.DelegatorInfo? {
+    return FlowIDTableStaking.getDelegatorInfo(nodeID: nodeID, delegatorID: delegatorID)
+}
+```
+
+### Get Total Staked FLOW
+```cadence
+import "FlowIDTableStaking"
+
+access(all) fun main(): UFix64 {
+    return FlowIDTableStaking.getTotalStaked()
+}
+```
+
+### Get Staking Rewards
+```cadence
+import "FlowIDTableStaking"
+
+access(all) fun main(): UFix64 {
+    return FlowIDTableStaking.getEpochTokenPayout()
+}
+```
+
+---
+
+## NFT Collection Queries
+
+### Get NFT IDs in Collection
+```cadence
+import "NonFungibleToken"
+
+access(all) fun main(address: Address, collectionPublicPath: PublicPath): [UInt64] {
+    let account = getAccount(address)
+    let collection = account.capabilities
+        .borrow<&{NonFungibleToken.Collection}>(collectionPublicPath)
+        ?? panic("Could not borrow NFT collection from \(address) at \(collectionPublicPath)")
+    return collection.getIDs()
+}
+```
+
+### Get NFT Count
+```cadence
+import "NonFungibleToken"
+
+access(all) fun main(address: Address, collectionPublicPath: PublicPath): Int {
+    let account = getAccount(address)
+    if let collection = account.capabilities
+        .borrow<&{NonFungibleToken.Collection}>(collectionPublicPath) {
+        return collection.getIDs().length
+    }
+    return 0
+}
+```
+
+### Check If Collection Exists
+```cadence
+import "NonFungibleToken"
+
+access(all) fun main(address: Address, collectionPublicPath: PublicPath): Bool {
+    let account = getAccount(address)
+    return account.capabilities
+        .borrow<&{NonFungibleToken.Collection}>(collectionPublicPath) != nil
+}
+```
+
+### Get NFT Display Metadata
+```cadence
+import "NonFungibleToken"
+import "MetadataViews"
+
+access(all) fun main(
+    address: Address,
+    collectionPublicPath: PublicPath,
+    nftID: UInt64
+): MetadataViews.Display? {
+    let account = getAccount(address)
+    let collection = account.capabilities
+        .borrow<&{NonFungibleToken.Collection}>(collectionPublicPath)
+        ?? panic("Could not borrow collection")
+    let nft = collection.borrowNFT(nftID) ?? panic("NFT \(nftID) not found")
+    return nft.resolveView(Type<MetadataViews.Display>()) as? MetadataViews.Display
+}
+```
+
+---
+
+## EVM & Cross-VM Queries
+
+### Get EVM Address for Flow Address
+```cadence
+import "EVM"
+
+access(all) fun main(address: Address): String? {
+    let account = getAccount(address)
+    if let coa = account.capabilities
+        .borrow<&EVM.CadenceOwnedAccount>(/public/evm) {
+        return coa.address().toString()
+    }
+    return nil
+}
+```
+
+### Get COA EVM Balance
+```cadence
+import "EVM"
+
+// Returns EVM balance (in attoFLOW) for a Flow account's COA, if it has one
+access(all) fun main(flowAddress: Address): UInt? {
+    if let coa = getAccount(flowAddress).capabilities
+        .borrow<&EVM.CadenceOwnedAccount>(/public/evm) {
+        return coa.address().balance().inAttoFLOW()
+    }
+    return nil
+}
+```
+
+> **See also:** `query-blockchain.md` for CLI commands to execute these scripts.

--- a/plugins/flow-dev/skills/flow-cli/references/commands-overview.md
+++ b/plugins/flow-dev/skills/flow-cli/references/commands-overview.md
@@ -83,19 +83,25 @@ iex "& { $(irm 'https://raw.githubusercontent.com/onflow/flow-cli/master/install
 | `flow config remove <type> <name>` | Remove config entry |
 | `flow config validate` | Validate flow.json |
 
-### Scheduled Transactions
-| Command | Purpose |
-|---------|---------|
-| `flow schedule setup` | Initialize scheduler resource |
-| `flow schedule list <account>` | List scheduled transactions |
-| `flow schedule get <id>` | Get scheduled tx details |
-| `flow schedule cancel <id>` | Cancel scheduled tx |
-
 ### Development
 | Command | Purpose |
 |---------|---------|
 | `flow emulator` | Start local emulator |
 | `flow cadence lint` | Lint Cadence code |
+| `flow mcp` | Start LSP-powered MCP server for Cadence development in Claude Code |
+
+### Signatures
+| Command | Purpose |
+|---------|---------|
+| `flow signatures generate <message> --signer <account>` | Sign a message with an account's key |
+| `flow signatures verify <hex-message> <hex-sig> <pub-key>` | Verify a message signature |
+
+### FLIX (Flow Interaction Templates)
+| Command | Purpose |
+|---------|---------|
+| `flow flix execute <id-or-name>` | Execute a FLIX template |
+| `flow flix package <name>` | Package transactions into FLIX format |
+| `flow flix generate <txFile>` | Generate FLIX template from transaction |
 
 ## Global Flags
 
@@ -133,3 +139,34 @@ flow accounts get 0x1234 --output json --save account.json --network mainnet
 --network testnet     # Testnet — access.devnet.nodes.onflow.org:9000
 --network mainnet     # Mainnet — access.mainnet.nodes.onflow.org:9000
 ```
+
+## MCP Server Setup
+
+Add Flow's LSP-powered MCP server to Claude Code for real-time Cadence language intelligence:
+
+```bash
+claude mcp add cadence-mcp -- flow mcp
+```
+
+Exposed tools inside Claude Code:
+
+| Tool | Description |
+|------|-------------|
+| `cadence_check` | Check Cadence file for compile errors |
+| `cadence_hover` | Type information at cursor position |
+| `cadence_definition` | Go to definition |
+| `cadence_symbols` | List all symbols in a file |
+| `cadence_completion` | Code completions |
+| `get_contract_source` | Get deployed contract source by name |
+| `get_contract_code` | Get contract code by address and name |
+| `cadence_execute_script` | Execute a Cadence script |
+| `cadence_code_review` | Review Cadence code for issues |
+
+Requires: Flow CLI installed, `flow mcp` available in PATH.
+
+## Deprecated Commands
+
+| Command | Status | Replacement |
+|---------|--------|-------------|
+| `flow dev` | Deprecated | Use emulator directly: `flow emulator` |
+| `flow run` | Deprecated alias | Was alias for `flow dev` |

--- a/plugins/flow-dev/skills/flow-cli/references/project.md
+++ b/plugins/flow-dev/skills/flow-cli/references/project.md
@@ -132,6 +132,17 @@ flow dependencies list
 flow dependencies discover
 ```
 
+### Short Alias: `flow deps`
+
+```bash
+# Same as flow dependencies install
+flow deps install testnet://8a4dce54554b225d.NumberFormatter
+flow deps install mainnet://f233dcee88fe0abe.FungibleToken
+
+# List installed dependencies
+flow deps list
+```
+
 ## Configuration Management
 
 ```bash
@@ -149,22 +160,6 @@ flow config remove deployment testnet my-account MyToken
 flow config validate
 ```
 
-## Scheduled Transactions
-
-```bash
-# Setup scheduler resource (one-time per account)
-flow schedule setup --network testnet --signer my-account
-
-# List scheduled transactions
-flow schedule list my-account --network testnet
-
-# Get details for specific scheduled tx
-flow schedule get 123 --network testnet
-
-# Cancel a scheduled transaction
-flow schedule cancel 123 --network testnet --signer my-account
-```
-
 ## Key Management
 
 ```bash
@@ -179,6 +174,8 @@ flow keys derive <private-key>
 ```
 
 ## Emulator
+
+> **Deprecated:** `flow dev` and `flow run` are deprecated. Use `flow emulator` directly for local development.
 
 ```bash
 # Start emulator

--- a/plugins/flow-dev/skills/flow-cli/references/query-blockchain.md
+++ b/plugins/flow-dev/skills/flow-cli/references/query-blockchain.md
@@ -1,0 +1,189 @@
+# Flow CLI — Query Blockchain
+
+## Decision Table
+
+| What you need | Command |
+|---------------|---------|
+| Account info, balance, keys, contracts | `flow accounts get <address>` |
+| Latest or specific block | `flow blocks get latest` / `flow blocks get <id-or-height>` |
+| Events by type in block range | `flow events get <EventType> <start> <end>` |
+| Collection by ID | `flow collections get <collectionID>` |
+| Transaction by ID | `flow transactions get <txID>` |
+| System transaction for a block | `flow transactions get-system <block>` |
+| Execute read-only Cadence script | `flow scripts execute <file.cdc> [args]` |
+| Historical script at block height | `flow scripts execute <file.cdc> --block-height <N>` |
+
+---
+
+## Commands
+
+### `flow accounts get`
+
+```bash
+# Basic — shows balance, keys, and contracts
+flow accounts get 0xf8d6e0586b0a20c7 --network mainnet
+
+# Include specific fields
+flow accounts get 0xf8d6e0586b0a20c7 --include contracts --network mainnet
+
+# JSON output for scripting
+flow accounts get 0xf8d6e0586b0a20c7 --output json --network mainnet
+
+# Filter to single field
+flow accounts get 0xf8d6e0586b0a20c7 --filter Balance --network mainnet
+```
+
+**Output fields:** `Address`, `Balance` (FLOW in UFix64), `Keys` (index, weight, algorithm), `Contracts` (name → code hash).
+
+---
+
+### `flow blocks get`
+
+```bash
+# Latest block
+flow blocks get latest --network mainnet
+
+# By block height
+flow blocks get 12884163 --network mainnet
+
+# By block ID
+flow blocks get abc123def456... --network mainnet
+
+# JSON output
+flow blocks get latest --output json --network mainnet
+```
+
+**Output fields:** `BlockID`, `ParentID`, `Height`, `Timestamp`, `CollectionGuarantees`, `Seals`, `PayloadHash`.
+
+---
+
+### `flow events get`
+
+```bash
+# Events in block range (inclusive)
+flow events get A.1654653399040a61.FlowToken.TokensWithdrawn 0 100 --network mainnet
+
+# With JSON args filter
+flow events get "A.f233dcee88fe0abe.FungibleToken.TokensDeposited" 15000000 15000100 \
+  --network mainnet --output json
+
+# Using short network alias
+flow events get A.0b2a3299cc857e29.TopShot.Deposit 0 latest -n mainnet
+```
+
+**Event type format:** `A.<contract-address>.<ContractName>.<EventName>`
+
+---
+
+### `flow collections get`
+
+```bash
+flow collections get <collectionID> --network mainnet
+```
+
+**Output:** Transaction IDs included in the collection.
+
+---
+
+### `flow transactions get`
+
+```bash
+# Basic
+flow transactions get <txID> --network mainnet
+
+# Include signatures, code, and fee events
+flow transactions get <txID> --include signatures,code,fee-events --network mainnet
+
+# JSON
+flow transactions get <txID> --output json --network mainnet
+```
+
+**Output fields:** `Status`, `ID`, `Payer`, `Authorizers`, `Proposal Key`, `Payload Signatures`, `Envelope Signatures`, `Events`, `Arguments`, `Error` (if failed).
+
+---
+
+### `flow transactions get-system`
+
+```bash
+# System transaction for latest block
+flow transactions get-system latest --network mainnet
+
+# System transaction for specific block height
+flow transactions get-system 12884163 --network mainnet
+```
+
+System transactions are protocol-level (epoch transitions, slashing, etc.) — not user-submitted.
+
+---
+
+### `flow scripts execute`
+
+```bash
+# Simple address argument
+flow scripts execute cadence/scripts/GetBalance.cdc 0xf8d6e0586b0a20c7 --network mainnet
+
+# JSON arguments (required for UFix64, arrays, structs, optionals)
+flow scripts execute cadence/scripts/GetNFTs.cdc \
+  --args-json '[{"type": "Address", "value": "0xf8d6e0586b0a20c7"}]' \
+  --network mainnet
+
+# Historical query at block height
+flow scripts execute cadence/scripts/GetBalance.cdc 0xf8d6e0586b0a20c7 \
+  --block-height 12000000 --network mainnet
+
+# At specific block ID
+flow scripts execute cadence/scripts/GetBalance.cdc 0xabc123... \
+  --block-id def456... --network mainnet
+```
+
+**Argument type mapping for `--args-json`:**
+
+| Cadence type | JSON type value |
+|-------------|-----------------|
+| `Address` | `"Address"` |
+| `String` | `"String"` |
+| `UInt64` | `"UInt64"` |
+| `UFix64` | `"UFix64"` |
+| `Bool` | `"Bool"` |
+| `Optional<T>` | `"Optional"` with nested value |
+| `[T]` | `"Array"` with items array |
+| `{K: V}` | `"Dictionary"` with key/value pairs |
+
+---
+
+## Standard Contract Addresses
+
+Core Flow contracts across environments:
+
+| Contract | Mainnet | Testnet | Emulator |
+|----------|---------|---------|----------|
+| `FungibleToken` | `0xf233dcee88fe0abe` | `0x9a0766d93b6608b7` | `0xee82856bf20e2aa6` |
+| `FlowToken` | `0x1654653399040a61` | `0x7e60df042a9c0868` | `0x0ae53cb6e3f42a79` |
+| `NonFungibleToken` | `0x1d7e57aa55817448` | `0x631e88ae7f1d7c20` | `0xf8d6e0586b0a20c7` |
+| `MetadataViews` | `0x1d7e57aa55817448` | `0x631e88ae7f1d7c20` | `0xf8d6e0586b0a20c7` |
+| `NFTStorefrontV2` | `0x4eb8a10cb9f87357` | `0x2d55b98eb200daef` | — |
+| `FlowIDTableStaking` | `0x8624b52f9ddcd04a` | `0x9eca2b38b18b5dfe` | `0xf8d6e0586b0a20c7` |
+| `FlowEpoch` | `0x8624b52f9ddcd04a` | `0x9eca2b38b18b5dfe` | `0xf8d6e0586b0a20c7` |
+| `FlowClusterQC` | `0x8624b52f9ddcd04a` | `0x9eca2b38b18b5dfe` | `0xf8d6e0586b0a20c7` |
+| `FlowDKG` | `0x8624b52f9ddcd04a` | `0x9eca2b38b18b5dfe` | `0xf8d6e0586b0a20c7` |
+| `FlowServiceAccount` | `0xe467b9dd11fa00df` | `0x8c5303eaa26202d6` | `0xf8d6e0586b0a20c7` |
+| `FlowFees` | `0xf919ee77447b7497` | `0x912d5440f7e3769e` | `0xe5a8b7f23e8b548f` |
+| `FlowStorageFees` | `0xe467b9dd11fa00df` | `0x8c5303eaa26202d6` | `0xf8d6e0586b0a20c7` |
+| `Crypto` | `0xf8d6e0586b0a20c7` | `0xf8d6e0586b0a20c7` | `0xf8d6e0586b0a20c7` |
+| `EVM` | `0xe467b9dd11fa00df` | `0x8c5303eaa26202d6` | `0xf8d6e0586b0a20c7` |
+| `FlowEVMBridge` | `0x1e4aa0b87d10b141` | `0xdfc20aee650fcbdf` | — |
+| `HybridCustody` | `0xd8a7e05a7ac670c0` | `0x294e44e1ec6993c6` | — |
+| `CapabilityFactory` | `0xd8a7e05a7ac670c0` | `0x294e44e1ec6993c6` | — |
+| `CapabilityFilter` | `0xd8a7e05a7ac670c0` | `0x294e44e1ec6993c6` | — |
+| `ViewResolver` | `0x1d7e57aa55817448` | `0x631e88ae7f1d7c20` | `0xf8d6e0586b0a20c7` |
+| `Burner` | `0xf233dcee88fe0abe` | `0x9a0766d93b6608b7` | `0xee82856bf20e2aa6` |
+| `FungibleTokenMetadataViews` | `0xf233dcee88fe0abe` | `0x9a0766d93b6608b7` | `0xee82856bf20e2aa6` |
+| `FungibleTokenSwitchboard` | `0xf233dcee88fe0abe` | `0x9a0766d93b6608b7` | `0xee82856bf20e2aa6` |
+| `RandomBeaconHistory` | `0xe467b9dd11fa00df` | `0x8c5303eaa26202d6` | `0xf8d6e0586b0a20c7` |
+| `NodeVersionBeacon` | `0xe467b9dd11fa00df` | `0x8c5303eaa26202d6` | `0xf8d6e0586b0a20c7` |
+| `AccountCreationReserve` | `0xe467b9dd11fa00df` | `0x8c5303eaa26202d6` | — |
+| `StakingCollection` | `0x8d0e87b65159ae63` | `0x95e019a17d0e23d7` | — |
+
+> **In Cadence code**, always use string imports (`import "FungibleToken"`) with flow.json contract aliases rather than hardcoding addresses.
+
+> **See also:** `cadence-scripts.md` for ready-to-use scripts for common queries.

--- a/plugins/flow-dev/skills/flow-defi/SKILL.md
+++ b/plugins/flow-dev/skills/flow-defi/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: flow-defi
+description: |
+  Architecture guide for building DeFi protocols on the Flow blockchain. Covers Flow's DeFi-specific advantages (MEV-free EVM, cross-VM atomic transactions, SPoCKs, on-chain automation), core DeFi primitives (lending health factors, interest rate kink models, AMM type selection), liquidity bootstrapping strategy (veFLOW, Merkl, CL ranges, bootstrapping benchmarks), and the current Flow DeFi ecosystem map (existing protocols, missing primitives, opportunity analysis).
+  TRIGGER when: designing a lending protocol on Flow, choosing AMM type for a DEX, liquidity bootstrapping strategy, veFLOW mechanics, "how does Flow DeFi work", "AMM types on Flow", "liquidity bootstrapping", "Flow DeFi ecosystem", "cross-VM composability for DeFi", "health factors", "interest rate curves", "collateral design", "DEX TVL", "Merkl integration", "missing DeFi primitives on Flow", "perp DEX on Flow", "launchpad on Flow", "COA pattern", "MEV-free EVM".
+  DO NOT TRIGGER when: writing DeFi transaction code in Cadence (use cadence-defi-actions), designing token economics (use flow-tokenomics), asking about Cadence syntax (use cadence-lang).
+---
+
+# Flow DeFi Architecture
+
+Design and build DeFi protocols on Flow — covering architectural advantages, core primitives, liquidity strategy, and the ecosystem landscape.
+
+## Navigation Map
+
+| Task | Reference |
+|------|-----------|
+| Flow DeFi foundations: COAs, MEV-free EVM, cross-VM atomicity, on-chain automation | [protocol-architecture.md](references/protocol-architecture.md) |
+| Core primitives: lending models, AMM type selection guide, risk framework | [defi-primitives.md](references/defi-primitives.md) |
+| Liquidity bootstrapping: veFLOW, Merkl, CL ranges, failure modes, benchmarks | [liquidity-strategy.md](references/liquidity-strategy.md) |
+| Ecosystem map: current state, missing primitives, opportunity analysis | [ecosystem-map.md](references/ecosystem-map.md) |
+
+## Key Principles
+
+1. **MEV-free EVM** — Flow's architecture prevents sandwich attacks on the EVM side; LP positions retain more yield
+2. **Cross-VM atomicity** — A single Cadence transaction can call EVM contracts atomically (no bridges for Cadence↔EVM)
+3. **COA pattern** — Cadence Owned Accounts bridge Cadence logic and EVM contracts within the same address space
+4. **On-chain automation** — FlowTransactionScheduler (FLIP 330) enables recurring transactions without keeper bots
+5. **Lock-up or lose** — Liquidity programs without lock-ups lose 60–80% TVL within 30 days
+
+## Companion Skills
+
+- **`cadence-defi-actions`** — Use to write the actual Cadence transaction code for DeFi operations (Source/Sink/Swapper). This skill is for architecture decisions; cadence-defi-actions is for implementation.
+- **`flow-tokenomics`** — Use alongside when designing the token economics for your DeFi protocol (veFLOW-style governance token, fee distribution, etc.).
+- **`cadence-lang`** — Consult for Cadence language rules when implementing protocol contracts.
+- **`cadence-audit`** — Use to audit protocol contracts before deployment.

--- a/plugins/flow-dev/skills/flow-defi/references/defi-primitives.md
+++ b/plugins/flow-dev/skills/flow-defi/references/defi-primitives.md
@@ -1,0 +1,167 @@
+# DeFi Primitives on Flow
+
+Core building blocks for DeFi protocol design. Covers lending architecture, AMM selection, and risk frameworks.
+
+---
+
+## Lending Protocol Design
+
+### Health Factor Model
+
+Standard collateralized lending uses a health factor to determine liquidation risk:
+
+```
+Health Factor = (Collateral Value × Collateral Factor) / Total Borrowed Value
+
+Healthy:     HF > 1.2  (safe zone)
+Warning:     HF 1.0–1.2 (approaching liquidation)
+Liquidatable: HF < 1.0
+```
+
+**Threshold design:**
+
+| Parameter | Conservative | Standard | Aggressive |
+|-----------|-------------|----------|------------|
+| Target HF | 1.5 | 1.3 | 1.15 |
+| Min HF (rebalance trigger) | 1.2 | 1.1 | 1.05 |
+| Liquidation HF | 1.0 | 1.0 | 1.0 |
+| Collateral factor (blue-chip) | 70% | 75% | 80% |
+| Collateral factor (mid-cap) | 50% | 60% | 65% |
+| Collateral factor (volatile) | 30% | 40% | 50% |
+
+### Interest Rate Kink Model
+
+Two-slope interest rate model that accelerates rates above the optimal utilization point:
+
+```
+If utilization ≤ optimalUtilization:
+  borrowRate = baseRate + (utilization / optimalUtilization) × slope1
+
+If utilization > optimalUtilization:
+  excessUtilization = utilization - optimalUtilization
+  maxExcess = 1.0 - optimalUtilization
+  borrowRate = baseRate + slope1 + (excessUtilization / maxExcess) × slope2
+```
+
+**Typical parameters:**
+
+| Parameter | Conservative | Standard | Aggressive |
+|-----------|-------------|----------|------------|
+| Base rate | 0% | 1% | 2% |
+| Optimal utilization | 80% | 85% | 90% |
+| Slope 1 (below optimal) | 4% | 5% | 7% |
+| Slope 2 (above optimal) | 75% | 100% | 150% |
+| Max rate (100% util) | ~79% | ~106% | ~159% |
+
+**Why kink model:** The steep slope2 above optimal utilization creates a strong economic incentive for LPs to add liquidity and for borrowers to repay — self-balancing mechanism.
+
+### Collateral Tiers
+
+Assign collateral factors by asset risk profile:
+
+| Tier | Assets | Max CF | Rationale |
+|------|--------|--------|-----------|
+| 1 — Blue chip | FLOW, ETH, BTC | 75–80% | High liquidity, deep markets |
+| 2 — Stablecoins | USDC, USDT, DAI | 85–90% | Low volatility |
+| 3 — Mid-cap | Major DeFi tokens | 55–65% | Moderate liquidity |
+| 4 — Volatile | Small-cap, new tokens | 30–45% | High volatility, thin markets |
+| 5 — Restricted | LP tokens, exotic | 0–30% | Circular risk, manipulation risk |
+
+### Liquidation Mechanics
+
+```cadence
+// Liquidation reward pattern
+let liquidationBonus = 0.05  // 5% bonus to liquidators
+let maxLiquidation = 0.5     // Max 50% of position per liquidation
+
+// Liquidator receives: repaidDebt × (1 + liquidationBonus) in collateral
+// Protocol receives: small fee (0.5–1%) from liquidation bonus
+```
+
+**Soft vs hard liquidation:** Many protocols now implement soft liquidation (partial close, rebalance) before hard liquidation (full close). This reduces bad debt but requires more complex accounting.
+
+---
+
+## AMM Type Selection Guide
+
+| AMM Type | Best for | Capital efficiency | Complexity | Examples |
+|----------|----------|-------------------|------------|---------|
+| **xy=k (CPMM)** | Long-tail, new pairs, wide price range | Low | Low | Uniswap v2, early AMMs |
+| **StableSwap** | Pegged assets (USDC/USDT, ETH/stETH) | High for peg | Medium | Curve, Balancer stable |
+| **CLMM** | Established pairs, active LPs | Very high (10–100×) | High | Uniswap v3, Increment |
+| **DLMM (bins)** | Volatile pairs, market making | Extreme (at current price) | Very high | Meteora, LFJ |
+| **ve(3,3) / Solidly** | Governance-integrated liquidity | Medium | High | Aerodrome, Velodrome |
+
+### Decision Framework
+
+```
+New protocol, bootstrapping liquidity
+  → Start with xy=k (simpler, broader range, less active management)
+  → Migrate to CLMM after establishing price discovery
+
+Stablecoin pairs (USDC/FLOW, FLOW/stFLOW)
+  → StableSwap (Curve-style) — dramatically lower slippage near peg
+
+Established token pairs with active LPs
+  → CLMM — 10–100× capital efficiency vs xy=k
+
+Need governance + liquidity coupling
+  → ve(3,3) — veFLOW votes direct emissions to your pool
+
+Market making for new token (tight spreads)
+  → DLMM — place all liquidity in current price bin
+```
+
+### CLMM Range Selection
+
+For a token with annualized volatility `σ`:
+
+```
+Suggested range width = price × σ × √(days / 365) × 2
+
+Example: FLOW at $1.00, 80% annual vol, 30-day LP period:
+range = 1.00 × 0.80 × √(30/365) × 2 = ±0.47
+→ LP range: $0.53 to $1.47
+```
+
+Tighter range = higher fee yield (more of your liquidity at price) but more frequent rebalancing.
+
+> **Note:** This formula is a linear approximation. For large σ√(days/365) values (> 0.5), use the log-normal bounds instead: upper = price × e^(σ√(days/365)), lower = price × e^(−σ√(days/365)).
+
+---
+
+## Risk Framework
+
+### Five DeFi Risk Categories
+
+| Risk | Description | Mitigation |
+|------|-------------|-----------|
+| **Collateral cascade** | Price drop → liquidations → more price drop | Conservative CFs, circuit breakers, isolated markets |
+| **Oracle dependency** | Price manipulation → bad debt | TWAP oracles, multiple sources, staleness checks |
+| **Smart contract** | Bug in protocol code → fund loss | Audits, formal verification, timelocks, bug bounties |
+| **Liquidity fragility** | Sudden LP withdrawal → high slippage, bank run | Lock-ups, withdrawal fees, gradual release |
+| **Governance attack** | Flash loan voting → malicious parameter changes | Snapshot lookback, timelock, quorum requirements |
+
+### Oracle Safety Rules
+
+```cadence
+// ❌ Never use spot price from AMM as oracle
+let spotPrice = amm.getSpotPrice()  // manipulatable in same transaction
+
+// ✅ Use TWAP (time-weighted average price)
+let twapPrice = oracle.getTWAP(token: tokenAddress, period: 1800)  // 30-min TWAP
+
+// ✅ Sanity check with deviation bounds
+assert(
+    twapPrice > lastKnownPrice * 0.5 && twapPrice < lastKnownPrice * 2.0,
+    message: "Oracle price deviation exceeds 2× — possible manipulation"
+)
+```
+
+### Circular Collateral Risk
+
+**Problem:** Using your own protocol's LP token as collateral creates circular risk — if the protocol is under stress, collateral value and borrowed assets both collapse together.
+
+**Rule:** Never allow LP tokens from your own protocol as Tier 1 collateral. If allowed at all, use maximum 20–30% CF with additional safeguards.
+
+> **See also:** `liquidity-strategy.md` for bootstrapping and sustaining liquidity for your protocol. `protocol-architecture.md` for Flow-specific architectural advantages.

--- a/plugins/flow-dev/skills/flow-defi/references/ecosystem-map.md
+++ b/plugins/flow-dev/skills/flow-defi/references/ecosystem-map.md
@@ -1,0 +1,142 @@
+# Flow DeFi Ecosystem Map
+
+Current state of DeFi on Flow, missing primitives, and opportunity analysis.
+
+---
+
+## Current State (Q1 2026)
+
+| Metric | Value |
+|--------|-------|
+| DEX TVL | ~$30–50M |
+| Daily DEX volume | ~$2–5M |
+| DEX/CEX volume ratio | ~15% (improving) |
+| Lending TVL | ~$10–20M |
+| Active DeFi protocols | ~8–12 |
+
+---
+
+## Existing Primitives
+
+### DEXes
+
+| Protocol | AMM Type | Notes |
+|----------|----------|-------|
+| IncrementFi | CLMM + xy=k | Largest DEX by TVL; Flow's primary AMM |
+| KittyPunch | xy=k | Simpler pairs, community DEX |
+| Metapier | StableSwap | Stablecoin-focused |
+
+### Bridges
+
+| Bridge | Architecture | Use case |
+|--------|-------------|----------|
+| Wormhole | Lock/mint | CEX canonical bridge; high security guarantees |
+| deBridge | Cross-chain message | User-facing bridge; faster UX |
+
+**Bridge selection guide:**
+- Wormhole for CEX integrations and high-value transfers (proven security)
+- deBridge for user-facing UI where speed matters
+- Native Crescendo bridge for EVM↔Cadence within Flow (no bridge needed)
+
+### Lending
+
+Early-stage lending markets exist on Flow; sector is underdeveloped vs lending volume on comparable chains.
+
+---
+
+## Missing Primitives (Opportunity Map)
+
+### 1. Perp DEX
+
+**Opportunity:** No established perpetual futures exchange on Flow.
+
+**Prerequisites before building:**
+- $30–50M DEX spot TVL (needed for perp funding rate arbitrage)
+- Reliable oracle infrastructure for mark prices
+- 6–12 months of DEX price history for funding rate credibility
+
+**Flow advantage:** MEV-free execution → no front-running of liquidations, no sandwich attacks on margin calls. On Ethereum perp DEXes, liquidators extract significant value from position closes.
+
+**Current status:** Prerequisites not yet met. Build in 2026–2027 horizon.
+
+### 2. Prediction Markets
+
+**Opportunity:** Sports prediction market on Flow with direct wallet integration.
+
+**Flow advantage:** Sports-engaged user base (NBA Top Shot, NFL All Day, UFC Strike) — organic alignment for sports prediction markets. Flow has approximately 1M MAU (Flow Foundation, early 2026). Native VRF for provably fair resolution. MEV-free for fair price discovery.
+
+**Architecture:** Cadence contract for position management + EVM for liquidity pools (cross-VM atomic) + RandomBeaconHistory for randomness.
+
+**Current status:** Immediate opportunity. Low competition, strong user-fit.
+
+### 3. Launchpad
+
+**Opportunity:** Token launch platform leveraging Flow's MEV-free environment.
+
+**MEV-free advantage for launches:**
+- Bonding curve purchases are front-run on every other chain
+- On Flow: all buyers get fair access at the same step of the curve
+- No sniping bots drain the first buyers
+
+**Bonding curve mechanics:**
+```
+Price = initialPrice × (1 + k)^tokensSold
+where k = graduation parameter (typically 0.00001–0.0001)
+
+Graduation threshold: typically 10–20% of supply sold
+→ Protocol receives initial bonding curve liquidity
+→ Migrates to DEX at graduation with POL from curve proceeds
+```
+
+**Graduation threshold design:**
+- Pump.fun model: 80% sold on bonding curve, 20% to DEX LP
+- Conservative: 50% sold on curve → more DEX liquidity at graduation
+
+### 4. Yield Aggregator
+
+Compound positions across Flow DeFi protocols automatically. Low complexity, high TVL leverage.
+
+---
+
+## Competitor Pull Factors and Flow Counter-Narrative
+
+Understanding why developers choose other chains — and how to position against them:
+
+| Chain | Why developers choose it | Flow counter-narrative |
+|-------|--------------------------|----------------------|
+| Solana | Speed, low fees, large DeFi ecosystem | Flow has better sports/gaming users + MEV-free |
+| Base | Coinbase distribution, EVM compatibility | Flow supports EVM AND Cadence; better for novel DeFi |
+| Sui | Object model similar to Flow | Flow has established sports/gaming user base, more liquidity |
+
+**Flow's strongest positioning:**
+1. Sports/gaming-engaged users that other chains don't have
+2. MEV-free environment (structural advantage for LPs and users)
+3. Cross-VM atomic composability (unique vs all competitors)
+4. Native account abstraction (wallets are first-class, no plugins needed)
+
+---
+
+## DefiLlama Adapter
+
+Required for protocol credibility — without a DefiLlama listing, most DeFi users won't consider the protocol serious.
+
+**Integration steps:**
+1. Fork `DefiLlama/DefiLlama-Adapters`
+2. Create `projects/<your-protocol>/index.js`
+3. Implement `tvl()` function querying your contracts
+4. Submit PR (typically 1–2 week review)
+
+Minimum viable adapter:
+```javascript
+const { getFlowTVL } = require("../helper/flow");
+
+module.exports = {
+  flow: {
+    tvl: async () => {
+      return getFlowTVL(/* your contract addresses */);
+    }
+  }
+};
+```
+
+> **See also:** `liquidity-strategy.md` for bootstrapping approach once you have product-market fit. `defi-primitives.md` for technical architecture of each primitive type.

--- a/plugins/flow-dev/skills/flow-defi/references/liquidity-strategy.md
+++ b/plugins/flow-dev/skills/flow-defi/references/liquidity-strategy.md
@@ -1,0 +1,135 @@
+# Liquidity Strategy
+
+Bootstrapping and sustaining liquidity for DeFi protocols on Flow.
+
+---
+
+## Bootstrapping Benchmarks
+
+### Gold Standard: Base/Aerodrome
+- Protocol-owned liquidity seeded at launch (reported ~$4M — verify exact figure)
+- Reached $1B+ TVL by month 13 (late 2023); stabilized in the $500M–$800M range through 2024–2025
+- Revenue exceeded emissions within approximately 2 years (self-sustaining phase)
+- Among the most capital-efficient liquidity bootstrapping programs deployed to date
+
+### Key Finding: Lock-Up is Non-Negotiable
+Programs without lock-up lose **60–80% of TVL within 30 days** of incentives ending.
+Lock-ups of 1–4 weeks retain 40–60% of peak TVL post-incentive.
+
+---
+
+## veFLOW Design
+
+Flow's native ve(3,3) governance token mechanic:
+
+| Component | Details |
+|-----------|---------|
+| Lock period | 1 week to 4 years (longer = more voting power) |
+| Voting | Lock FLOW → receive veFLOW → vote for pools weekly |
+| Fee distribution | 100% of trading fees from voted pools → veFLOW holders |
+| Bribes | External protocols pay veFLOW holders to vote for their pools |
+| Emissions | Protocol emissions directed to pools by vote weight |
+| Rebase | Weekly FLOW rebase to veFLOW holders (dilution protection) |
+
+**Protocol integration strategy:**
+1. Acquire veFLOW (buy FLOW, lock for max period)
+2. Vote for your protocol's pools every epoch
+3. Attract third-party veFLOW votes via bribes
+4. Bribe market ROI: $1 in bribes → $3–8 in emissions (Curve Wars precedent)
+
+---
+
+## Merkl Integration
+
+Merkl (by Angle Protocol) is an off-chain reward distribution infrastructure usable for on-chain verified distributions.
+
+### Setup Process
+1. Deploy your incentive budget to Merkl's distributor contract
+2. Configure your pool address and reward token
+3. Merkl indexes LP positions, calculates rewards based on active liquidity
+4. LPs claim rewards from Merkl's on-chain distributor
+
+### Economics
+| Parameter | Typical Value |
+|-----------|--------------|
+| Merkl fee | 3% of incentive budget |
+| Break-even TVL | $200K+ (below this, direct emissions more efficient) |
+| Minimum campaign | $5,000 in incentives |
+| Reward calculation | Based on active liquidity (CLMM-aware) |
+
+**Merkl advantage vs direct emissions:** Rewards only pay LPs with active liquidity (in range for CLMMs) — no wasted emissions on out-of-range positions. Typically 2–4× more capital-efficient than naive LP mining.
+
+---
+
+## CL Range Selection for Incentive Programs
+
+When designing CLMM incentive ranges for a ve(3,3) or Merkl campaign:
+
+```
+Incentivize the ±20–30% range from current price for most pairs
+→ Captures active LPs without incentivizing "parking" liquidity far out of range
+
+For stablecoin pairs: ±0.5–2% (very tight, near peg)
+For high-volatility pairs: ±50–100% (wider to retain LPs through volatility)
+```
+
+Range selection formula for 30-day campaigns:
+```
+Optimal range width = historical_30d_volatility × 1.5
+(multiply by 2 for 90-day campaigns)
+```
+
+---
+
+## Six Failure Modes
+
+| Failure Mode | Symptom | Mitigation |
+|-------------|---------|-----------|
+| **Mercenary capital** | 80%+ TVL leaves when incentives end | Require lock-ups (minimum 7 days) |
+| **Token price dependency** | Protocol APY drops as token price drops | Real yield component; diversify reward tokens |
+| **Wrong pairs incentivized** | TVL in illiquid/unused pairs | Incentivize pairs with actual trading volume |
+| **Emission rate too high** | Token inflation → death spiral | Max emission rate = 10% annual supply; reduce over time |
+| **No on-chain demand** | TVL with no trading volume | Integrate aggregators before launching incentives |
+| **No switching cost** | LPs exit instantly for next opportunity | Lock-up + loyalty bonuses; NFT LP positions |
+
+---
+
+## Protocol-Owned Liquidity (POL)
+
+**Why POL:** Rented liquidity (incentivized LPs) leaves when incentives end. Owned liquidity stays and generates permanent fees.
+
+**Acquisition methods:**
+1. **Direct purchase:** Protocol treasury buys LP position
+2. **Bond program (Olympus-style):** Users sell LP tokens to protocol at discount for vested protocol tokens
+3. **Fee reinvestment:** Compound trading fees back into LP positions
+
+**POL target:** 15–20% of total pool TVL — enough to maintain price stability if all rented LPs exit.
+
+**Bond design:**
+- Discount: 5–10% below market price (attractive but not too dilutive)
+- Vesting: 5–7 day cliff (long enough to prevent arbitrage, short enough to attract participants)
+- Capacity limit: Max 5% of circulating supply per epoch
+
+---
+
+## Pre-Incentive Volume Tactics
+
+Launch order matters: TVL without volume is worthless; volume without liquidity is unusable.
+
+**Week 1–2 before incentive launch:**
+
+| Tactic | Goal |
+|--------|------|
+| GeckoTerminal listing | Organic discovery, volume tracking |
+| DefiLlama adapter | TVL indexing (required for protocol credibility) |
+| Arb bot attraction | Consistent small-volume baseline, price discovery |
+| Trading competition | $5–10K prize pool generates 50–200× in volume during event |
+
+**Trading competition design (Drift Volume Wars model):**
+- 2-week duration
+- Prize pool funded by protocol treasury
+- Tiers: top 50 traders by volume → reduces sybil risk vs top 1000
+- Minimum trade size ($100) → prevents artificial volume inflation
+- Whitelist 3–5 eligible pairs → concentrates liquidity where you need it
+
+> **See also:** `ecosystem-map.md` for current Flow DeFi landscape and missing primitive opportunities. `flow-tokenomics` skill for the governance token design that powers veFLOW-style mechanics.

--- a/plugins/flow-dev/skills/flow-defi/references/protocol-architecture.md
+++ b/plugins/flow-dev/skills/flow-defi/references/protocol-architecture.md
@@ -121,16 +121,4 @@ access(all) fun getRandomSeed(blockHeight: UInt64): [UInt8] {
 
 **DeFi applications:** Fair lottery/raffle contracts, randomized NFT drops, prediction market resolution.
 
----
-
-## Security Event: Cadence v1.8.8 Type Confusion (December 2025)
-
-A type confusion vulnerability in the Cadence runtime (v1.8.8) was discovered and exploited on mainnet on December 26–27, 2025. The vulnerability allowed resource duplication via incorrect type assertion handling, enabling an attacker to drain approximately $3.9M from affected contracts. The Flow network was briefly paused; the vulnerability was patched in v1.8.9.
-
-**What developers should know:**
-- The exploit occurred on mainnet; all contracts running on v1.8.8 were at risk
-- The network was paused and the vulnerability patched in v1.8.9+; current mainnet is safe
-- Audit checklist: review any code that performs `x as? ConcreteType` on values from external contracts, especially across contract upgrade boundaries
-- Source: Flow Foundation security disclosure, December 2025
-
 > **See also:** `defi-primitives.md` for building blocks (lending models, AMM selection). `cadence-defi-actions` skill for writing the Cadence transaction code that powers these protocols.

--- a/plugins/flow-dev/skills/flow-defi/references/protocol-architecture.md
+++ b/plugins/flow-dev/skills/flow-defi/references/protocol-architecture.md
@@ -1,0 +1,136 @@
+# Flow DeFi Protocol Architecture
+
+## Three Structural Advantages
+
+### 1. MEV-Free EVM
+Flow's consensus architecture separates transaction ordering from execution. Validators cannot reorder transactions to extract MEV (no front-running, no sandwich attacks) on the EVM side.
+
+**DeFi implication:** LP positions retain significantly more fee yield vs Ethereum/Base where MEV bots extract 5–15% of AMM fees. This is a structural LP yield premium for Flow DEXes.
+
+### 2. Cross-VM Atomic Transactions
+A single Cadence transaction can call both Cadence contracts and EVM contracts atomically. Either everything executes or nothing does — with no bridge required.
+
+```cadence
+// Single transaction: Cadence logic + EVM call — atomic
+transaction() {
+    prepare(signer: auth(BorrowValue) &Account) {
+        let coa = signer.storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(
+            from: /storage/evm
+        ) ?? panic("No COA found")
+
+        // Call an EVM contract atomically within this Cadence transaction
+        // evmContractAddress is an EVM.EVMAddress (e.g., obtained from a stored address or COA)
+        let result = coa.call(
+            to: evmContractAddress,
+            data: calldata,
+            gasLimit: 200000,
+            value: EVM.Balance(attoflow: 0)
+        )
+    }
+}
+```
+
+**Supported since:** Crescendo upgrade (September 2024)
+
+### 3. SPoCKs (Specialized Proofs of Confidential Knowledge)
+SPoCKs are a consensus-layer cryptographic mechanism used by Flow execution nodes to prove they correctly executed a chunk of transactions without revealing the full computation. This is an internal node-protocol primitive — **not accessible to DeFi application developers** and not relevant to Cadence contract or transaction logic.
+
+> **Note:** Privacy-preserving DeFi features (hidden order books, sealed auctions) are not natively enabled by SPoCKs. They require application-layer design patterns.
+
+---
+
+## COA Pattern (Cadence Owned Accounts)
+
+COAs bridge Cadence and EVM within a single Flow address. One Flow account controls both a Cadence storage space and an EVM address.
+
+### Creating a COA
+```cadence
+transaction() {
+    prepare(signer: auth(SaveValue, BorrowValue, Capabilities) &Account) {
+        // Create COA (one-time per account)
+        if signer.storage.borrow<&EVM.CadenceOwnedAccount>(from: /storage/evm) == nil {
+            let coa <- EVM.createCadenceOwnedAccount()
+            signer.storage.save(<-coa, to: /storage/evm)
+            let cap = signer.capabilities.storage.issue<&EVM.CadenceOwnedAccount>(/storage/evm)
+            signer.capabilities.publish(cap, at: /public/evm)
+        }
+    }
+}
+```
+
+### Using COA for EVM Calls
+```cadence
+// Borrow COA with call permission
+let coa = signer.storage.borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(
+    from: /storage/evm
+) ?? panic("COA not found")
+
+// Encode EVM calldata (ABI encoding)
+let calldata: [UInt8] = /* ABI-encoded function call */
+
+// Call EVM contract
+let result = coa.call(
+    to: evmContractAddress,
+    data: calldata,
+    gasLimit: 100000,
+    value: EVM.Balance(attoflow: 0)
+)
+```
+
+### COA Architecture Use Cases
+| Pattern | How |
+|---------|-----|
+| Cadence NFT + EVM royalties | COA holds EVM revenue, Cadence logic distributes |
+| Hybrid DEX | Cadence order book + EVM AMM liquidity pools |
+| Cross-chain bridge endpoint | Cadence validates, COA executes EVM mint/burn |
+| Protocol-owned EVM liquidity | Cadence governance controls EVM LP positions |
+
+---
+
+## On-Chain Automation (FlowTransactionScheduler)
+
+**FLIP 330** introduces `FlowTransactionScheduler` — a native protocol mechanism for scheduling recurring Cadence transactions without off-chain keeper infrastructure.
+
+### Key Properties
+- Transactions execute automatically at specified intervals or block heights
+- No external trigger required (unlike Keeper networks on EVM)
+- Fees deducted from the scheduling account's balance
+
+### Use Cases for DeFi
+- Automated rebalancing (AutoBalancer pattern)
+- Interest accrual updates (lending protocols)
+- Epoch transitions (staking/vesting contracts)
+- Reward distribution (no cron bots)
+
+### Setup Pattern
+`FlowTransactionScheduler` is a Cadence contract deployed on mainnet since the Forte upgrade (October 2025). Scheduling is done via Cadence transactions to that contract — there is no separate `flow schedule` CLI command. Consult the `FlowTransactionScheduler` contract documentation for the current Cadence API.
+
+---
+
+## VRF Randomness
+
+Flow provides on-chain verifiable random numbers via the `RandomBeaconHistory` contract — no oracle required.
+
+```cadence
+import "RandomBeaconHistory"
+
+access(all) fun getRandomSeed(blockHeight: UInt64): [UInt8] {
+    return RandomBeaconHistory.sourceOfRandomness(atBlockHeight: blockHeight).value
+}
+```
+
+**DeFi applications:** Fair lottery/raffle contracts, randomized NFT drops, prediction market resolution.
+
+---
+
+## Security Event: Cadence v1.8.8 Type Confusion (December 2025)
+
+A type confusion vulnerability in the Cadence runtime (v1.8.8) was discovered and exploited on mainnet on December 26–27, 2025. The vulnerability allowed resource duplication via incorrect type assertion handling, enabling an attacker to drain approximately $3.9M from affected contracts. The Flow network was briefly paused; the vulnerability was patched in v1.8.9.
+
+**What developers should know:**
+- The exploit occurred on mainnet; all contracts running on v1.8.8 were at risk
+- The network was paused and the vulnerability patched in v1.8.9+; current mainnet is safe
+- Audit checklist: review any code that performs `x as? ConcreteType` on values from external contracts, especially across contract upgrade boundaries
+- Source: Flow Foundation security disclosure, December 2025
+
+> **See also:** `defi-primitives.md` for building blocks (lending models, AMM selection). `cadence-defi-actions` skill for writing the Cadence transaction code that powers these protocols.

--- a/plugins/flow-dev/skills/flow-react-sdk/references/setup.md
+++ b/plugins/flow-dev/skills/flow-react-sdk/references/setup.md
@@ -19,7 +19,7 @@ function Root() {
   return (
     <FlowProvider
       config={{
-        accessNodeUrl: 'https://access-mainnet.onflow.org',
+        accessNodeUrl: 'https://rest-mainnet.onflow.org',
         flowNetwork: 'mainnet',
         appDetailTitle: 'My On Chain App',
         appDetailIcon: 'https://example.com/icon.png',
@@ -46,7 +46,7 @@ export default function FlowProviderWrapper({ children }: { children: React.Reac
   return (
     <FlowProvider
       config={{
-        accessNodeUrl: 'https://access-mainnet.onflow.org',
+        accessNodeUrl: 'https://rest-mainnet.onflow.org',
         flowNetwork: 'mainnet',
         appDetailTitle: 'My On Chain App',
       }}
@@ -98,7 +98,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
 ```tsx
 // Mainnet
-config={{ accessNodeUrl: 'https://access-mainnet.onflow.org', flowNetwork: 'mainnet' }}
+config={{ accessNodeUrl: 'https://rest-mainnet.onflow.org', flowNetwork: 'mainnet' }}
 
 // Testnet
 config={{ accessNodeUrl: 'https://access-testnet.onflow.org', flowNetwork: 'testnet' }}

--- a/plugins/flow-dev/skills/flow-tokenomics/SKILL.md
+++ b/plugins/flow-dev/skills/flow-tokenomics/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: flow-tokenomics
+description: |
+  Framework for designing token economics for Flow-based protocols. Covers economic first principles (Fisher Equation MV=PQ, Nash equilibrium, mechanism design, behavioral economics), proven design patterns with metrics (Real Yield/GMX, Buyback/Hyperliquid, veToken/Curve) and failure case studies (Olympus, Terra, Anchor), token value accrual mechanisms, TGE launch playbook with 12-week timeline, DAO governance models and attack vectors, and regulatory compliance (Howey Test, SEC precedents, MiCA, tax treatment).
+  TRIGGER when: designing token mechanics, token value accrual, token launch strategy, DAO governance design, veToken model, buyback vs burn vs real yield, Howey Test analysis, token vesting design, anti-Sybil strategy, tokenomics for a protocol, token distribution, staking design, governance attack vectors, securities compliance, TGE planning, points programs, airdrop design, "what token model should I use", "is my token a security".
+  DO NOT TRIGGER when: designing DeFi protocol architecture (use flow-defi), writing Cadence token contracts (use cadence-tokens), FT/NFT interface standards (use cadence-tokens).
+---
+
+# Flow Tokenomics
+
+Design token economics for Flow-based protocols — from first principles through launch strategy, governance, and regulatory considerations.
+
+## Navigation Map
+
+| Task | Reference |
+|------|-----------|
+| Economic foundations: Fisher Equation, Nash equilibrium, mechanism design, behavioral economics | [first-principles.md](references/first-principles.md) |
+| Pattern library: 5 proven patterns with metrics, 5 anti-patterns with failures, supply design | [design-patterns.md](references/design-patterns.md) |
+| Revenue-to-token mechanisms: real yield, buyback/burn, P/E framework, Howey Test by mechanism | [value-accrual.md](references/value-accrual.md) |
+| TGE playbook: 12-week timeline, distribution options, failure archive, market psychology | [launch-strategy.md](references/launch-strategy.md) |
+| DAO governance models, attack vectors, defenses, regulatory compliance | [governance-compliance.md](references/governance-compliance.md) |
+
+## Key Principles
+
+1. **Velocity kills price** — High token velocity (fast rotation through wallets) suppresses price; sinks and lock-ups reduce velocity
+2. **Emissions without demand is poison** — Incentive programs must create real demand, not just TVL that exits when emissions end
+3. **Real yield > narrative** — Protocols generating actual revenue and sharing it survive market cycles; those relying on emissions alone don't
+4. **Lock-up or lose** — Programs without lock-up lose 60–80% of participants within 30 days of incentives ending
+5. **Deflationary mechanics require revenue** — Burns only work long-term if protocol revenue sustains or exceeds emission rate
+
+## Companion Skills
+
+- **`flow-defi`** — Use alongside when the token is for a DeFi protocol. Liquidity bootstrapping, veFLOW mechanics, and ecosystem positioning decisions affect tokenomics design.
+- **`cadence-tokens`** — Use when implementing the actual FT/NFT contracts for the token. This skill covers economic design; cadence-tokens covers Cadence implementation.
+- **`cadence-audit`** — Audit token contracts (staking, vesting, governance) before deployment.

--- a/plugins/flow-dev/skills/flow-tokenomics/references/design-patterns.md
+++ b/plugins/flow-dev/skills/flow-tokenomics/references/design-patterns.md
@@ -1,0 +1,189 @@
+# Token Design Patterns
+
+Proven patterns with real-world metrics, and anti-patterns with failure analyses.
+
+---
+
+## Five Proven Patterns
+
+### 1. Real Yield (Recommended Default)
+Distribute actual protocol revenue (not token inflation) to stakers.
+
+**Case study: GMX v1**
+- ~$470M cumulative fees generated (v1 era); 30% → GMX stakers in ETH, 70% → GLP LPs
+- Sustained 15–25% ETH APY during high-activity periods; token survived bear markets because cash flows were real
+- **Note:** GMX v2 (launched October 2024) restructured the fee model — staker ETH distribution was replaced with a buyback mechanism. Verify current GMX v2 mechanics if using as a reference
+
+**Case study: Synthetix**
+- Revenue from synth trading fees → SNX stakers
+- Stakers must maintain C-ratio (collateralization) — aligns incentives
+
+**When to use:** Protocol with genuine revenue ($1M+ annualized). Real yield loses credibility below this threshold.
+
+---
+
+### 2. Buyback & Burn
+Use protocol revenue to repurchase and burn circulating supply.
+
+**Case study: Hyperliquid (HYPE)**
+- 97% of trading fees → buyback
+- 5× price appreciation since TGE
+- Fixed supply, so burns create genuine deflation
+- Community-owned: 31% airdrop, no VC allocation
+
+**Case study: BNB**
+- Quarterly burns based on revenue
+- Auto-burn mechanism: transparent formula
+- Still operating after 7+ years
+
+**When to use:** Early-stage protocol with revenue but not enough to meaningfully yield individual stakers. Burns compound over time.
+
+**Critical finding:** 7 of 9 tokens with buyback programs decline anyway. Exceptions share: >30% buyback ratio, fixed supply, strong narrative, zero/minimal VC allocation.
+
+---
+
+### 3. veToken (Governance Coupling)
+Lock tokens to receive voting power that directs protocol emissions.
+
+**Case study: Curve (CRV/veCRV)**
+- Lock CRV for up to 4 years → veCRV
+- 40–50% of total supply locked
+- Voting power directs gauge weights (emissions to pools)
+- Created the "Curve Wars" — protocols pay billions in bribes to veCRV holders
+- Convex Finance built a $3B protocol on top of this primitive
+
+**Mechanics:**
+```
+Lock 1 CRV for 4 years → 1 veCRV
+Lock 1 CRV for 1 year → 0.25 veCRV
+veCRV decays linearly to 0 → incentive to re-lock
+```
+
+**When to use:** Protocols that need to direct liquidity (DEXes, lending markets). Creates sustainable incentive flywheel.
+
+---
+
+### 4. Dual-Token
+Separate governance/staking token from yield-bearing/stable token.
+
+**Case study: MKR/DAI**
+- DAI: stability mechanism (soft-peg to $1)
+- MKR: governance token (burned when surplus, minted when undercollateralized)
+- MKR holders absorb tail risk in exchange for fees
+
+**Case study: GMX/GLP**
+- GMX: governance + fee-sharing staking token
+- GLP: LP index token (holds basket of assets; earns 70% of fees)
+- Different risk profiles attract different investors
+
+**When to use:** Protocol needs both a stable medium of exchange AND a governance/value-capture token.
+
+---
+
+### 5. NFT + Token Hybrid
+NFTs as governance assets with token utility.
+
+**Case study: Nouns DAO**
+- 1 Noun auctioned daily forever (no max supply)
+- Noun holders vote on treasury ($40M+) allocations
+- Revenue from auctions → treasury → community grants
+- No pre-mine, no VC allocation
+
+**When to use:** Community-first protocols, creative/cultural projects, DAOs prioritizing long-term governance over token speculation.
+
+---
+
+## Five Anti-Patterns
+
+### 1. Pure Governance (No Cash Flow)
+Governance rights alone don't drive token value.
+
+**Case study: UNI (Uniswap)**
+- $1T+ in trading volume generated
+- 0% of fees → UNI holders (all fees to LPs)
+- UNI holder receives no cash flow, only theoretical governance rights
+- Token price driven entirely by speculation, not fundamentals
+
+**Lesson:** Governance without fee switch is marketing, not value accrual.
+
+---
+
+### 2. Excessive Emissions
+High emissions collapse token price, destroying the APY they're supposed to offer.
+
+**Case study: Olympus (OHM)**
+- Peak APY: 8,000%+ 
+- Required constant new buyers to maintain price
+- Death spiral: price fell → APY in dollar terms fell → fewer buyers → more price pressure
+- Peak: $1,400 → Trough: $10 (-99%)
+
+**Rule:** Max annual emission rate = 10% of circulating supply. Reduce over time.
+
+---
+
+### 3. Algorithmic Stables Without Backing
+Stablecoins backed only by their paired governance token cannot survive bank runs.
+
+**Case study: TerraLUNA**
+- UST maintained peg via LUNA mint/burn
+- During panic: UST → sell LUNA → LUNA price falls → UST peg breaks → more LUNA minted → hyperinflation
+- $40 billion in value destroyed in 72 hours
+
+**Rule:** Stablecoins require $1+ in collateral per $1 in circulation. Algorithmic mechanisms can optimize, not replace, collateral.
+
+---
+
+### 4. Ponzi Yield
+Unsustainably high yields funded by new deposits, not protocol revenue.
+
+**Case study: Anchor Protocol**
+- 20% APY on UST "guaranteed" by Terraform Labs
+- Subsidized from TFL treasury, not real yield
+- Attracted $18B in deposits
+- Collapsed when TFL could no longer sustain subsidies
+
+**Rule:** If you can't explain where the yield comes from, it's a Ponzi.
+
+---
+
+### 5. Heavy Insider Allocation
+Large VC/founder allocations create persistent sell pressure.
+
+**Case studies:**
+- Aptos (APT): 51.5% to insiders → botted airdrop, -50% in 48h
+- ICP (Internet Computer): 40%+ to insiders → -95% from peak
+
+**Best practice:**
+```
+Community/public: 40–50%
+Foundation/treasury: 20–25%
+Team (vested): 15–20%
+Investors (vested): 10–15%
+Advisors: 2–5%
+```
+
+---
+
+## Supply Design Options
+
+| Model | Example | Best for | Risk |
+|-------|---------|----------|------|
+| **Fixed supply** | Bitcoin (21M) | Strong store-of-value narrative | No flexibility for incentives |
+| **Capped + burns** | BNB (200M→100M) | DeFi protocols with revenue | Requires sustained burns |
+| **Uncapped + sinks** | ETH, CRV | Protocols needing ongoing emissions | Inflation if sinks fail |
+| **Elastic** | Ampleforth | Stable unit of account | Complex, confusing UX |
+
+**Recommended default for new Flow protocols:** Capped supply with transparent burn mechanism tied to protocol revenue.
+
+---
+
+## Context Decision Matrix
+
+| Stage | Revenue | Community | Recommended pattern |
+|-------|---------|-----------|-------------------|
+| Pre-launch | None | Small | Points program → retroactive airdrop |
+| Early ($0–500K ARR) | Low | Growing | veToken + small emissions |
+| Growth ($500K–5M ARR) | Moderate | Established | Real yield + buybacks |
+| Mature ($5M+ ARR) | High | Large | Real yield + governance |
+
+> **See also:** `value-accrual.md` for implementation details of each revenue mechanism. `launch-strategy.md` for TGE execution.

--- a/plugins/flow-dev/skills/flow-tokenomics/references/first-principles.md
+++ b/plugins/flow-dev/skills/flow-tokenomics/references/first-principles.md
@@ -1,0 +1,123 @@
+# Tokenomics First Principles
+
+Economic and game-theory foundations for token design.
+
+---
+
+## Fisher Equation: MV = PQ
+
+The quantity theory of money applied to token economics:
+
+```
+M = Money supply (circulating token supply)
+V = Velocity (how often tokens change hands per period)
+P = Price per token
+Q = Quantity of economic activity (GDP equivalent for the protocol)
+```
+
+Rearranged: `P = (M × V) / Q` — **to increase P, increase Q or decrease V**.
+
+### Velocity Reduction Strategies
+
+| Strategy | Mechanism | Velocity reduction |
+|----------|-----------|-------------------|
+| **Staking** | Lock tokens → earn yield | High (locked supply exits float) |
+| **Vesting cliff** | Founders/investors can't sell immediately | High (supply suppressed) |
+| **NFT-gated utility** | Hold token → access features | Medium (incentivizes holding) |
+| **Governance power** | Voting power increases with hold duration | Medium |
+| **Sink mechanics** | Burns on each transaction | Medium (reduces M) |
+| **Exit penalty** | Fee for early unstaking | Low-medium (discourages exit) |
+
+**Common mistake:** Building demand without sinks. Every new use case increases Q (demand) but if it also increases velocity (people buy-use-sell), P can still fall.
+
+---
+
+## Nash Equilibrium Design
+
+The goal: make "hold" the dominant strategy in the token's game theory.
+
+### Why Olympus (3,3) Failed
+
+Olympus claimed a Nash equilibrium where all players choosing to "bond" and "stake" (coded as "(3,3)") was optimal. It worked until it didn't:
+
+| Condition | Holding optimal? |
+|-----------|-----------------|
+| APY > expected price decline | ✅ Yes — stake and collect yield |
+| APY < expected price decline | ❌ No — sell now, buy back cheaper |
+| Everyone thinks everyone will sell | ❌ Mass exit is rational → self-fulfilling |
+
+**Result:** Olympus fell from $1,400 to $10 (-99%) because defection became rational when price momentum reversed. The "(3,3)" equilibrium was only stable in bull markets.
+
+### Designing Stable Equilibria
+
+A holding equilibrium is stable when:
+1. **Holding provides real cash flow** — not just more tokens (which dilute)
+2. **Exit has meaningful cost** — vesting cliff, time lock, or burned tokens on exit
+3. **Network effects increase with holders** — more holders → more utility → more demand
+
+**GMX model (stable, v1):**
+- Hold GMX → receive 30% of protocol fees in ETH *(v1 mechanism; GMX v2, October 2024, replaced this with a buyback model)*
+- Cash flow denominated in ETH (not GMX) — no reflexivity
+- No exit penalty, but exiting means losing ongoing cash flow
+- Equilibrium: hold GMX if you believe protocol will generate more fees
+
+---
+
+## Mechanism Design Principles
+
+### 1. Sybil Resistance
+
+| Method | Cost barrier | Time barrier | Social barrier |
+|--------|-------------|--------------|----------------|
+| Proof of Work | High (hardware) | High | None |
+| Proof of Stake | High (capital) | Medium (lockup) | None |
+| Social graph (Gitcoin Passport) | Medium | Medium | High |
+| KYC | Low | Medium | High |
+| Activity threshold | Low | High | None |
+
+**For airdrop Sybil resistance:** Combine time (wallet age > 90 days) + activity (5+ transactions) + capital (held > $100 in protocol). Makes farming economically unviable for most attackers.
+
+### 2. Anti-Gaming
+
+Mechanisms break when rational actors optimize against them rather than for their stated purpose:
+
+| Bad design | Gaming attack | Fix |
+|------------|--------------|-----|
+| Reward volume | Wash trading | Reward net volume or unique counterparties |
+| Reward TVL | Borrow-and-deposit loop | Reward non-collateralized TVL only |
+| Reward wallet count | Multi-wallet sybil | Social proof + activity threshold |
+| Reward early users | Point farmers | Time-weighted + quality actions |
+
+### 3. Long-Term Alignment Mechanisms
+
+- **Vesting cliffs:** 6–12 month cliff + 2–3 year linear vest for founders/investors
+- **Multiplier Points (GMX):** Stake longer → earn multiplier tokens → higher yield share (non-transferable, lost on unstake — punishes exit)
+- **Time-weighted voting:** Quadratic increase in voting power with lock duration (reduces whale dominance for short-term holders)
+- **Exit penalty redistribution:** Early unstake penalty → distributed to remaining stakers (creates positive externality from exits)
+
+---
+
+## Behavioral Economics
+
+### Loss Aversion in Vesting Design
+
+People feel losses 2× more intensely than equivalent gains (Kahneman-Tversky prospect theory). Apply to token mechanics:
+
+- **Cliff as streak-loss:** Frame 12-month cliff as "you've earned X tokens — unstake before maturity and lose them all" rather than "you'll receive tokens after 12 months"
+- **Sunk cost lock-in:** Once users have staked for 3+ months, the cliff loss-aversion keeps them locked
+- **Progress bars:** Show "67% vested" not "4 more months" — the former triggers completion psychology
+
+### Endowment Effect in Airdrops
+
+People value things more once they own them. Airdrop mechanics:
+- **Drop first, explain later:** Users who receive tokens and then learn what they're for are more engaged than users who research before receiving
+- **Tiered revelation:** Reveal larger airdrop amounts in stages (build excitement and commitment)
+- **Identity attachment:** "Your allocation reflects your contribution to X" — ties token to identity
+
+### FOMO Mechanics
+
+- **Scarcity:** Fixed supply, transparent burn rate, countdown to unlock cliff
+- **Social proof:** Leaderboards, public staker counts, whale wallet tracking
+- **Asymmetric upside framing:** "Only 500 wallets hold enough tokens for governance rights" (scarcity signal)
+
+> **See also:** `design-patterns.md` for proven token models with real-world metrics. `value-accrual.md` for revenue-to-token mechanisms.

--- a/plugins/flow-dev/skills/flow-tokenomics/references/governance-compliance.md
+++ b/plugins/flow-dev/skills/flow-tokenomics/references/governance-compliance.md
@@ -1,0 +1,157 @@
+# Governance & Regulatory Compliance
+
+DAO governance models, attack vectors, defenses, and regulatory considerations for token-based protocols.
+
+---
+
+## Governance Models
+
+| Model | How it works | Pros | Cons | Best for |
+|-------|-------------|------|------|---------|
+| **Token-weighted** | 1 token = 1 vote | Simple, familiar | Whale dominance | Most DeFi DAOs |
+| **Quadratic** | Vote power = √(tokens) | Reduces whale power | Sybil-vulnerable | Community DAOs with identity |
+| **Conviction** | Voting weight grows over time | Reduces flash attacks | Complex UX | Grants programs |
+| **Delegation** | Delegate voting to representatives | Overcomes apathy | Centralization risk | Token-weighted DAOs |
+| **Futarchy** | Markets predict policy outcomes | Theoretically optimal | Extremely complex, untested at scale | **Avoid for now** |
+
+**Practical recommendation:** Token-weighted with:
+- Delegation support (overcomes the 5–10% voter turnout problem)
+- 7-day timelocks on all parameter changes
+- Snapshot (off-chain) for non-binding sentiment; on-chain for binding governance
+
+---
+
+## Attack Vectors
+
+### 1. Flash Loan Governance Attack
+Borrow massive token supply within one transaction → pass malicious proposal → repay.
+
+**Real examples:**
+- **Beanstalk ($182M, April 2022):** Attacker flash-borrowed ~$1B in LP tokens via Aave to acquire a temporary supermajority → passed an emergency governance proposal granting the attacker the entire protocol treasury → drained $182M in the same transaction
+- **Build Finance ($11M, 2022):** Similar flash loan attack
+
+**Defenses (must implement ALL of these):**
+```
+- Snapshot lookback: Voting power = balance 48h BEFORE proposal creation
+  → Flash loans cannot affect already-counted balances
+- Time lock: 7-day delay between vote passing and execution
+  → Community can detect and counter-propose
+- Quorum requirement: 10–20% of circulating supply must vote
+  → Raises attack cost substantially
+```
+
+### 2. Governance Apathy
+Reality: 5–10% of token holders vote on average. Malicious minority can reach quorum.
+
+**Mitigations:**
+- Delegation: Allow passive holders to delegate to active voters
+- Voting reminders: Email/Discord notifications on new proposals
+- Metagovernance: Protocols like Convex hold large delegated positions
+- Low-consequence proposals first: Build voting habit with small decisions
+
+### 3. Vote Buying (Bribes)
+Legitimate at small scale (Curve Wars bribes). Becomes attack vector when:
+- Malicious actor controls >10% of governance through bribes
+- Bribe market prices are too low vs. treasury value
+
+**Bribe market economics:**
+- Historical bribe ROI: $1 in bribes → $3–8 in emissions directed
+- Attack becomes viable when treasury value >> cost to control governance
+
+**Defense:** Minimum governance threshold for sensitive proposals (e.g., treasury withdrawals require 25% quorum vs standard 10%)
+
+---
+
+## Governance Parameter Requirements
+
+| Parameter | Minimum | Recommended |
+|-----------|---------|-------------|
+| Snapshot lookback | 24h | 48h |
+| Voting period | 5 days | 7 days |
+| Timelock delay | 48h | 7 days |
+| Quorum | 5% | 10–20% |
+| Proposal threshold | 0.5% | 1–5% |
+| Execution delay | 24h | 48h |
+
+---
+
+## Proposal Structure Template
+
+Every governance proposal should include:
+
+1. **Title** — Clear, descriptive, no hyperbole
+2. **Summary** — 2–3 sentences: what it does and why
+3. **Motivation** — Problem being solved (data/evidence)
+4. **Specification** — Exact technical changes with contract addresses/parameters
+5. **Risk Analysis** — What could go wrong, magnitude, probability
+6. **Success Metrics** — How to measure if proposal achieved its goal
+7. **Timeline** — Implementation schedule with milestones
+8. **Voting Options** — "Yes, execute as specified" / "No" / "Abstain"
+
+---
+
+## Regulatory Framework
+
+### Howey Test (US Securities Law)
+
+Four criteria that must ALL be met for an asset to be a security:
+1. **Investment of money** — Purchaser pays money
+2. **Common enterprise** — Fortunes tied to others
+3. **Expectation of profit** — Buyer expects financial return
+4. **From efforts of others** — Profits depend on others' work
+
+**Application to tokens:**
+- Pure utility tokens that are consumed (not held for appreciation) → lower risk
+- Governance tokens with no cash flow → contested (UNI has not faced SEC action)
+- Staking rewards → criterion 4 (profits from team operating protocol) → higher risk
+- Fully decentralized (no controlling team) → criterion 4 fails → lower risk
+
+### SEC Enforcement Precedents
+
+| Case | Outcome | Lesson |
+|------|---------|--------|
+| Ripple (XRP) | Partial win: XRP not a security for secondary market sales | Programmatic sales ≠ investment contract |
+| Telegram (TON) | $1.7B settlement, TON shutdown | Pre-launch token sales = securities |
+| Coinbase (COIN) | SEC case filed 2023; status evolving — verify current state | Regulatory landscape is in flux as of 2026 |
+
+### Four Compliance Strategies
+
+1. **Utility framing:** Design token primarily for protocol utility (fee payment, staking). Document in whitepaper that token is not an investment.
+
+2. **Geographic restriction:** Block US persons from TGE (Reg S compliance). US investors can only purchase on secondary market.
+
+3. **Sufficient decentralization:** SAFT → token conversion once protocol is "sufficiently decentralized" (Ethereum precedent). Core team no longer controls protocol outcomes.
+
+4. **Governance gating:** Revenue distribution enabled only by governance vote — team does not unilaterally promise returns.
+
+**Recommendation:** Consult securities counsel in your jurisdiction. None of the above is legal advice.
+
+---
+
+## Tax Implications (US)
+
+| Event | Tax treatment |
+|-------|--------------|
+| Airdrop received | Ordinary income at FMV on receipt date (Rev. Rul. 2023-14) |
+| Staking rewards | Ordinary income at FMV on receipt (Rev. Rul. 2023-14) |
+| Token sale | Capital gain/loss (short-term if held < 1 year) |
+| NFT sale | Capital gain/loss |
+| DAO governance vote | Not taxable (no economic event) |
+
+**For founders:** Token grants/vesting → ordinary income at vesting unless Section 83(b) election filed within 30 days of grant.
+
+---
+
+## Global Overview
+
+| Jurisdiction | Framework | Key requirement |
+|-------------|-----------|----------------|
+| **EU** | MiCA (Markets in Crypto-Assets) | In full effect since December 2024. Stablecoins (ARTs/EMTs) require issuer authorization. Utility tokens must publish a whitepaper and notify the local regulator. |
+| **Singapore** | Payment Services Act (PSA) | DPT service providers require MAS license |
+| **Switzerland** | FINMA categories | Payment tokens, utility tokens, asset tokens — different treatment |
+| **Japan** | PSA + Financial Instruments | Crypto exchange registration required |
+| **Cayman Islands** | VASP Act | Popular incorporation jurisdiction; still requires compliance in operating jurisdictions |
+
+**MiCA (in effect December 2024):** If your token is accessible to EU users, you are already subject to MiCA. ARTs (asset-referenced tokens) and EMTs (e-money tokens) face the strictest requirements and require issuer authorization. Utility tokens: publish whitepaper, notify local regulator.
+
+> **See also:** `launch-strategy.md` for TGE planning timeline that incorporates legal milestones. `value-accrual.md` for Howey Test analysis by specific revenue mechanism type.

--- a/plugins/flow-dev/skills/flow-tokenomics/references/launch-strategy.md
+++ b/plugins/flow-dev/skills/flow-tokenomics/references/launch-strategy.md
@@ -1,0 +1,133 @@
+# Token Launch Strategy
+
+TGE playbook from planning through post-launch sustainability.
+
+---
+
+## Three-Phase Framework
+
+### Phase 1: Pre-Launch (8–12 weeks before TGE)
+
+**Week 1–4: Foundation**
+- [ ] Define token utility and value accrual mechanism (see `design-patterns.md`)
+- [ ] Legal review: Howey Test analysis, jurisdiction selection (see `governance-compliance.md`)
+- [ ] Design Sybil resistance criteria for airdrop/points
+- [ ] Deploy points program with clear, public rules
+- [ ] Seed community: Discord, Twitter, initial partner announcements
+
+**Week 5–8: Community Building**
+- [ ] Points program live; track activity publicly (leaderboard)
+- [ ] Launch testnet; reward genuine technical users
+- [ ] Partner with 3–5 protocols for joint incentives
+- [ ] Secure 2 exchange listings (at minimum: one CEX + DEX)
+- [ ] Prepare DEX liquidity: $2M+ minimum for Day 1
+
+**Week 9–12: Launch Preparation**
+- [ ] Publish tokenomics publicly (distribution, vesting, mechanics)
+- [ ] Complete security audit (2 auditors minimum)
+- [ ] Finalize airdrop list, apply Sybil filters
+- [ ] Governance framework ready (DAO structure, initial proposals)
+- [ ] Market maker agreements signed
+
+---
+
+### Phase 2: TGE
+
+**Ideal distribution:**
+
+| Recipient | Allocation | Notes |
+|-----------|-----------|-------|
+| Community/airdrop | 40–50% | Core to credibility; Hyperliquid did 31% |
+| Foundation/treasury | 20–25% | 3-year vesting, no cliff |
+| Team | 15–20% | 12-month cliff + 3-year linear vest |
+| Investors | 10–15% | 6-month cliff + 2-year vest |
+| Advisors | 2–5% | 12-month cliff + 2-year vest |
+
+**Day 1 requirements:**
+- DEX liquidity: $2M+ (prevents whale manipulation)
+- Protocol governance activated (community owns product from Day 1)
+- Staking live (immediate utility, absorbs sell pressure)
+- Announcement coordinated: protocol partners post simultaneously
+
+---
+
+### Phase 3: Post-Launch Stability (First 90 days)
+
+- **Week 1–2:** Monitor and respond to price discovery (expected volatility)
+- **Month 1:** First governance proposal live (signal active DAO)
+- **Month 2:** Revenue sharing active or first buyback executed
+- **Month 3:** Community transparency report (activity metrics, treasury state)
+
+**Ongoing:**
+- Quarterly burns or revenue distribution events
+- Monthly community calls
+- Protocol improvements via governance (not unilateral team decisions)
+
+---
+
+## Distribution Option Comparison
+
+| Method | Targeting | Sybil Risk | Engagement | Examples |
+|--------|-----------|-----------|-----------|---------|
+| **Retroactive Airdrop** | Past users | High | Medium | Uniswap, ENS |
+| **Points Program** | Active users | Medium | High | Hyperliquid |
+| **Fair Launch** | Anyone | Low | High | Nouns, YFI |
+| **Insider-Heavy** | VCs/team | None | Low | ICP, Aptos — **avoid** |
+
+**Recommended: Points Program → Retroactive Allocation**
+1. Define clear on-chain actions worth points (no off-chain promises)
+2. Run for 8–16 weeks
+3. Apply Sybil filter before snapshot
+4. Convert points to token allocation proportionally with a community bonus multiplier
+
+---
+
+## Anti-Sybil Strategies
+
+Layer multiple barriers:
+
+| Barrier type | Implementation | Difficulty to game |
+|-------------|----------------|-------------------|
+| Wallet age | Require account created >90 days before snapshot | Medium |
+| Activity threshold | 5+ on-chain transactions in protocol | Medium |
+| Capital threshold | Held >$100 in protocol at any point | High |
+| Social graph | Gitcoin Passport score >15 | High |
+| KYC | Optional; for maximum allocation tier | Very high |
+
+**Recommended layering:** (Wallet age 90d) AND (5+ transactions) AND (one of: $100 in protocol OR Passport score 15+)
+
+---
+
+## Failure Archive
+
+| Launch | What failed | Data | Lesson |
+|--------|------------|------|--------|
+| **Aptos (APT)** | Botted airdrop; heavy VC allocation (51.5%) | -50% in 48h | Anti-Sybil required; insider allocation destroys trust |
+| **Blast** | 100% incentive-driven TVL, no utility | -97% TVL after incentives ended | Build product before incentives |
+| **Arbitrum** | Near-perfect gold standard | ~625K qualifying addresses post-Sybil filter (from 1.13M initial claims); sustained TVL | Public criteria + long points program + genuine product |
+| **Hyperliquid** | Gold standard | 31% community airdrop, zero VC | Extreme community allocation + real product + buybacks |
+| **Drift Volume Wars** | Competition design model | Volume spikes during event, baseline increase after | Competitions with floor ($100 min) and tiers work |
+
+---
+
+## Market Psychology: 2026 Context
+
+**Current narrative landscape:**
+1. **Real yield** — Market rewards protocols with actual revenue. "Inflationary rewards" is a red flag.
+2. **Deflationary supply** — Buyback/burn mechanics command premium valuation.
+3. **Community ownership** — Low insider allocation (≤25%) seen as credibility signal.
+4. **Transparency** — On-chain verifiable everything. Off-chain promises = discounted.
+
+**Four-phase crypto cycle:**
+```
+Accumulation → Bull (retail) → Distribution → Bear → Accumulation
+```
+
+**2026 positioning:** Protocols launching in early bull or accumulation phase have best narrative leverage. Launches in late-bull face immediate sell pressure as early holders distribute.
+
+**Timing TGE:**
+- Launch when your protocol has 3+ months of activity data (credibility)
+- Do NOT launch at peak hype without product (Blast mistake)
+- Fear of missing bull market → rushed launch → failed TGE → worse than waiting
+
+> **See also:** `governance-compliance.md` for legal structure decisions that should be made before TGE. `value-accrual.md` for the post-launch revenue mechanism that drives long-term token health.

--- a/plugins/flow-dev/skills/flow-tokenomics/references/value-accrual.md
+++ b/plugins/flow-dev/skills/flow-tokenomics/references/value-accrual.md
@@ -1,0 +1,166 @@
+# Token Value Accrual Mechanisms
+
+How to route protocol revenue to token holders, with real-world benchmarks and regulatory analysis.
+
+---
+
+## Three Mechanism Types
+
+### 1. Real Yield — Revenue Sharing
+
+Direct distribution of protocol fees to token stakers in non-native (non-reflexive) currency.
+
+| Protocol | Revenue | Staker Share | Currency | Staker APY |
+|----------|---------|-------------|----------|-----------|
+| GMX v1 | ~$470M cumulative (v1) | 30% (v1) | ETH (v1) | 15–25% |
+| Synthetix | Variable | 100% | sUSD | 5–15% |
+| Jupiter | Variable | 50% | SOL/USDC | Variable |
+| EtherFi | Variable | 60% | ETH | ~8% |
+
+**Note:** GMX v2 (October 2024) replaced the ETH distribution with a buyback mechanism. The table reflects v1 metrics for reference only.
+
+**Why non-reflexive currency matters:**
+- Yield in ETH/USDC = real value regardless of token price
+- Yield in native token = printing; value depends on new buyers
+- GMX's ETH yield survived the 2022–2023 bear market; purely-inflationary protocols didn't
+
+**Implementation:**
+```cadence
+// Revenue collection pattern
+access(all) contract ProtocolFees {
+    access(all) var pendingDistribution: UFix64
+
+    // Called on each protocol interaction
+    access(contract) fun collectFee(amount: UFix64) {
+        let stakerShare = amount * 0.30
+        let lpShare = amount - stakerShare
+        self.pendingDistribution = self.pendingDistribution + stakerShare
+        // route lpShare to liquidity providers
+    }
+
+    // Callable by anyone (gas incentive) — distributes accumulated fees
+    access(all) fun distribute() {
+        // distribute self.pendingDistribution to stakers proportionally
+    }
+}
+```
+
+---
+
+### 2. Buyback & Burn
+
+Use protocol revenue to repurchase tokens from the market and permanently destroy them.
+
+| Protocol | Buyback Ratio | Supply model | Price performance |
+|----------|--------------|-------------|-------------------|
+| Hyperliquid | 97% of fees | Fixed | 5× since TGE |
+| BNB | Quarterly, auto-burn formula | Capped (200M→100M) | Survived 8+ years |
+| MakerDAO | $100M+ PSM surplus → buyback | Fixed | Sustained |
+| Uniswap (proposed) | Fee switch vote | Fixed | Not yet activated |
+
+**Critical finding:** 7 of 9 protocols with buyback programs still saw token price decline. The 2 exceptions (Hyperliquid, BNB) share:
+- Buyback ratio >30% of revenue
+- Fixed or capped supply (burns are meaningful)
+- Strong narrative (clear value prop)
+- Zero or minimal VC allocation (no persistent sell pressure)
+
+**Burn mechanics options:**
+
+| Method | How | Best for |
+|--------|-----|----------|
+| Manual quarterly burns | Protocol burns accumulated tokens on schedule | Transparency, predictability |
+| Auto-burn formula | Smart contract burns based on revenue formula | Trustless, continuous |
+| Fee-on-transfer burn | % burned on every token transfer | High-velocity tokens only |
+| Repurchase + burn | Buy from market → send to 0x0 | Tokens with deep liquidity |
+
+---
+
+### 3. Hybrid Mechanisms
+
+Split revenue between multiple destinations.
+
+**Jupiter (JUP) model:** 50% → buyback/burn, 50% → staker yield
+
+**EtherFi model:** 60% → stakers, 40% → treasury (for protocol development)
+
+**Common split formulas:**
+```
+Conservative: 20% stakers, 60% buyback, 20% treasury
+Balanced:     30% stakers, 40% buyback, 30% treasury  
+Growth:       40% stakers, 20% buyback, 40% treasury (reinvest in growth)
+```
+
+---
+
+## P/E Framework
+
+Protocol-to-earnings ratio — valuing tokens like businesses:
+
+```
+Token P/E = (Fully Diluted Valuation) / (Annualized Revenue distributed to holders)
+
+Token FDV:  Fully diluted market cap (price × max supply)
+Revenue:    Annual fees distributed to stakers/burned
+```
+
+**Example benchmarks (bull market valuations):**
+
+| Protocol | FDV | Annual Revenue | P/E |
+|----------|-----|----------------|-----|
+| GMX | ~$1B (peak) | ~$100M (peak v1) | ~10× (peak) |
+| AAVE | ~$5B | ~$30M | ~169× |
+| CRV | ~$2B | ~$100M | ~20× |
+| Hyperliquid | ~$15B | ~$200M | ~75× |
+
+**Interpretation:** P/E < 20× suggests undervalued relative to earnings. Note: these figures are from peak bull-market periods; current protocol revenues are substantially lower. Always use current data from DefiLlama when evaluating live protocols. P/E > 100× is speculative premium. Traditional finance benchmarks: 15–25× for stable businesses.
+
+---
+
+## Howey Test Analysis by Mechanism
+
+The Howey Test (from SEC v. W.J. Howey Co.) determines if an asset is a "security":
+1. Investment of money
+2. In a common enterprise
+3. With an expectation of profit
+4. Derived from the efforts of others
+
+**Risk assessment by mechanism:**
+
+| Mechanism | Howey risk | Reasoning |
+|-----------|-----------|-----------|
+| Real yield from staking | **High** | Expectation of profit from others' efforts (protocol team) |
+| Buyback/burn | **Medium** | Profit from market activity; less direct than yield |
+| Governance only | **Lower** | No direct profit expectation; but governance = control |
+| Utility token (pay fees) | **Lower** | Consumptive use, not investment |
+| DeFi primitive (liquidity) | **Varies** | Depends on passive vs active nature |
+
+**Mitigation strategies** (consult legal counsel; this is not legal advice):
+1. **Utility framing:** Token primarily used to pay for protocol services
+2. **Sufficient decentralization:** Protocol operates without core team control
+3. **Geographic restrictions:** Limit distribution to non-US users (Reg S)
+4. **Governance gating:** Revenue distribution requires active governance vote to enable
+
+---
+
+## Implementation Checklist
+
+Before deploying staking/burn contracts:
+
+**Staking Contract Security:**
+- [ ] Reentrancy protection (Cadence's resource model prevents most reentrancy)
+- [ ] Reward calculation does not use manipulable spot price
+- [ ] Emergency pause function controlled by multisig
+- [ ] Gradual reward distribution (not instant — prevents flash loan attacks)
+- [ ] Audit by two independent auditors
+
+**Burn Contract Security:**
+- [ ] Burn address is verifiably inaccessible (zero address or provably locked)
+- [ ] No mechanism to reverse burns
+- [ ] Supply tracking updated correctly after burns
+
+**Vesting Contract Security:**
+- [ ] Cliff enforced at contract level (not UI)
+- [ ] Beneficiary change requires multisig approval
+- [ ] Revocation mechanism exists for employee departures
+
+> **See also:** `design-patterns.md` for which mechanism to choose based on your stage. `governance-compliance.md` for full regulatory analysis and DAO structure.


### PR DESCRIPTION
## Summary
- Add new skills after analyzing Flow/Dapper skills (5 repos analyzed) + patch/update existing ones with relevant changes.
- **2 new skills**: `flow-defi` (4 references: protocol architecture, DeFi primitives, ecosystem map, liquidity strategy) and `flow-tokenomics` (5 references: first principles, design patterns, value accrual, governance/compliance, launch strategy)
- **3 new reference files** in existing skills: `flow-cli/query-blockchain.md` (26-contract address table), `flow-cli/cadence-scripts.md` (21 script recipes), `cadence-tokens/nft-advanced.md` (TraitModule, MetadataViews patterns)
- **Deleted** fabricated `flow-cli/findapi.md`
- **CLAUDE.md**: updated routing table and repository structure diagram

## Correctness fixes

- Fixed 9 wrong testnet addresses (service account group, HybridCustody group)
- Replaced non-existent `EVM.addressFromString()` with COA-based pattern (2 files)
- Removed fabricated `flow schedule` CLI commands and `flow deps --pin` flag
- Fixed flow-react-sdk access node URL: `access-mainnet` → `rest-mainnet`
- SPoCKs: "Speculative" → "Specialized"; removed false DeFi-developer claims
- Added $3.9M mainnet exploit (Dec 2025) to protocol-architecture.md
- MiCA: corrected "July 2026 deadline" → "in full effect since December 2024"
- GMX: distinguished v1 (ETH fee share) from v2/Oct-2024 (buyback model) across 3 files
- Hyperliquid buyback percentage: 93% → 97%
- Arbitrum airdrop: clarified ~625K qualifying addresses after Sybil filter
- Beanstalk: corrected flash-loan vector description
- Flow MAU: "3M+ sports-engaged wallets" → "~1M MAU (Flow Foundation, early 2026)"

## Cadence correctness fixes
- Transaction block order corrected: `prepare → pre → execute → post` (was `post` before `execute`) in `safety-testing.md`
- Post-conditions: replaced force-unwrap `!` with optional chaining `?.` to avoid side effects in `safety-testing.md` and `scaffold-defi.md`
- DeFi Actions: `uniqueID: nil` → `uniqueID: operationID` on `PoolSink` in `workflows.md`