### PR TITLE
feat(flow-orchestrate): multi-agent orchestrator skill for Flow development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ One plugin is registered in `.claude-plugin/marketplace.json`:
 
 - **flow-dev** (`plugins/flow-dev/`) — v1.0.0, category `blockchain`
 
-It contains exactly these eleven skills (each has its own `SKILL.md` plus a `references/` directory):
+It contains exactly these twelve skills (each has its own `SKILL.md` plus a `references/` directory):
 
 | Skill | Reference count |
 |---|---|
@@ -62,6 +62,7 @@ It contains exactly these eleven skills (each has its own `SKILL.md` plus a `ref
 | `flow-dev-setup` | 8 |
 | `flow-defi` | 4 |
 | `flow-tokenomics` | 5 |
+| `flow-orchestrate` | 10 |
 
 Descriptions and trigger phrases live in each `SKILL.md` frontmatter.
 
@@ -82,6 +83,7 @@ When a developer asks for help, use this table to determine which skill(s) to ac
 | Design token economics for a Flow protocol | `flow-tokenomics` | `flow-defi`, `cadence-tokens` |
 | Write unit tests for Cadence contracts | `cadence-testing` | `cadence-lang` |
 | Debug failing Cadence tests / add coverage | `cadence-testing` | `cadence-lang`, `cadence-audit` |
+| Multi-domain task: audit + deploy, full dapp, token launch end-to-end | `flow-orchestrate` | spawns sub-skills as needed |
 
 ## Install and Validate Commands
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Then install individual plugins:
 
 | Plugin | Description | Skills | Category |
 |--------|-------------|--------|----------|
-| **flow-dev** | Flow network development | `cadence-lang`, `cadence-tokens`, `cadence-audit`, `cadence-scaffold`, `cadence-testing`, `flow-react-sdk`, `flow-project-setup`, `flow-cli`, `flow-dev-setup`, `flow-defi`, `flow-tokenomics` | blockchain |
+| **flow-dev** | Flow blockchain development | `cadence-lang`, `cadence-tokens`, `cadence-audit`, `cadence-scaffold`, `cadence-testing`, `flow-react-sdk`, `flow-project-setup`, `flow-cli`, `flow-dev-setup`, `flow-defi`, `flow-tokenomics`, `flow-orchestrate` | blockchain |
 
 ### flow-dev
 
@@ -49,6 +49,7 @@ Skills for developing on the Flow network:
 | `flow-dev-setup` | Development environment setup: Flow CLI installation, emulator, VS Code extension, testing framework, dev wallet, frontend SDKs (FCL/React), EVM tooling (Hardhat/Foundry/Remix) |
 | `flow-defi` | Flow DeFi architecture: COAs, MEV-free EVM, cross-VM atomicity, lending health factor/kink models, AMM type selection, liquidity bootstrapping benchmarks, veFLOW, Merkl, ecosystem map |
 | `flow-tokenomics` | Token economics: Fisher Equation, Nash equilibrium, proven patterns (Real Yield/Buyback/veToken) with failure case studies, TGE 12-week playbook, DAO governance attack vectors, Howey Test, MiCA compliance |
+| `flow-orchestrate` | Multi-agent orchestrator: spawns specialized subagents for complex multi-domain tasks (audit + deploy, full dapp, token launch). Each agent loads only its domain refs — 80-90% leaner than a single monolithic context |
 
 ## Repository Structure
 
@@ -93,6 +94,10 @@ plugins/
             flow-tokenomics/
                 SKILL.md    # Tokenomics guide
                 references/ # 5 reference files
+            flow-orchestrate/
+                SKILL.md        # Orchestrator briefing + agent roster
+                agents/         # 8 agent templates (one per specialist)
+                references/     # task-routing.md, handoff-format.md
 ```
 
 ## Contributing

--- a/plugins/flow-dev/skills/cadence-lang/SKILL.md
+++ b/plugins/flow-dev/skills/cadence-lang/SKILL.md
@@ -37,6 +37,7 @@ Read the relevant reference file based on your task:
 | Security best practices | [security-best-practices.md](references/security-best-practices.md) |
 | Anti-patterns to avoid | [anti-patterns.md](references/anti-patterns.md) |
 | Design patterns | [design-patterns.md](references/design-patterns.md) |
+| CU cost by operation, optimization patterns, MAX_SAFE_N methodology | [cu-optimization.md](references/cu-optimization.md) |
 
 For security-sensitive tasks, also read `security-best-practices.md` and `anti-patterns.md`.
 

--- a/plugins/flow-dev/skills/cadence-lang/references/cu-optimization.md
+++ b/plugins/flow-dev/skills/cadence-lang/references/cu-optimization.md
@@ -1,0 +1,126 @@
+# Cadence CU Optimization
+
+Flow hard-caps every transaction at **9,999 CU**. Fees have two components:
+- Inclusion fee: 0.0001 FLOW (fixed)
+- Execution fee: CU × price_per_CU (≈ 4.0e-5 FLOW/CU)
+
+Extract real CU from the `FlowFees.FeesDeducted` event `amount` field after any sealed transaction.
+
+## CU Cost by Operation Type
+
+| Operation | CU cost | Notes |
+|-----------|---------|-------|
+| FT transfer (reference) | ~19 CU | Baseline for fee math |
+| `{UInt64: T}` dict write | ~7–8 CU | 2 hash passes + B+ tree traversal |
+| `[T]` array append | ~0.3–0.5 CU | Bounds check only |
+| `account.storage.borrow<&T>` | ~5 CU | Charged even if resource unchanged |
+| `StoragePath(identifier: s)` construction | ~1 CU | String allocation |
+| EVM `dryCall` (simple view) | ~50–100 CU | Varies with return data size |
+| EVM `coa.call` (state mutating) | ~200–500 CU | Plus EVM gas converted to CU |
+
+## High-CU Patterns to Avoid
+
+**Dict writes inside loops**
+```cadence
+// ❌ 7–8 CU per iteration
+for id in ids {
+    self.registry[id] = value
+}
+
+// ✅ ~0.4 CU per iteration — use array if keyed access not needed
+self.items.append(value)
+```
+
+**Borrow inside loops**
+```cadence
+// ❌ ~5 CU wasted per iteration even if resource unchanged
+for i in items {
+    let r = self.account.storage.borrow<&Counter>(from: /storage/counter)!
+    r.increment()
+}
+
+// ✅ borrow once, use reference for all iterations
+let counter = self.account.storage.borrow<&Counter>(from: /storage/counter)!
+for i in items {
+    counter.increment()
+}
+```
+
+**Path construction inside loops**
+```cadence
+// ❌ ~1 CU per iteration
+for id in ids {
+    let path = StoragePath(identifier: "vault_".concat(id.toString()))!
+}
+
+// ✅ construct once outside loop when path is constant
+let path = StoragePath(identifier: "vault_main")!
+```
+
+**Individual counter increments**
+```cadence
+// ❌ N transactions of 5 CU each
+for _ in items {
+    self.head = self.head + 1
+}
+
+// ✅ single bulk update
+self.head = self.head + UInt64(items.length)
+```
+
+## Resource Inlining
+
+Resources with total encoded size ≤ 512 bytes are inlined in their parent — zero extra storage read. If a resource exceeds 512 bytes it spills to a separate slot, adding CU on every access.
+
+```
+Rough field sizes (encoded):
+  UInt64      8 bytes
+  UFix64      8 bytes
+  Address    20 bytes
+  String      variable (length prefix + content)
+  Bool        1 byte
+
+Check: sum(field_sizes) ≤ 512 bytes → inlined → no extra CU
+```
+
+## Composite Key Packing
+
+```cadence
+// ❌ String key: 85 bytes, hashed twice per write
+let key = fromAddr.toString().concat("->").concat(toAddr.toString())
+self.edges[key] = weight
+
+// ✅ packed UInt64: 8 bytes, same hash cost
+let key: UInt64 = (UInt64(fromId) << 32) | UInt64(toId)
+self.edges[key] = weight
+```
+
+Only works when both components fit in UInt32 (max value ~4.3 billion each).
+
+## Sweep Methodology for Measuring MAX_SAFE_N
+
+Run the transaction at increasing N values and record the fee from `FlowFees.FeesDeducted`:
+
+```
+N = [64, 128, 256, 512, 768, 1024, 1280, 1536]
+```
+
+1. Find the cliff where the tx fails — binary-search the exact limit at ±4 entries.
+2. Plot fee vs N: y-intercept = fixed overhead, slope = CU/entry.
+3. Set MAX_SAFE_N = highest passing N with ≥10% headroom below 9,999 CU.
+
+```
+RECOMMENDED_FEE_PER_ENTRY = (FEE_PER_TX / MAX_SAFE_N) × 1.10
+```
+
+## EVM CU Interaction
+
+Cross-VM calls consume CU on the Cadence side in addition to EVM gas:
+
+| Call type | Cadence CU overhead | EVM gas |
+|-----------|---------------------|---------|
+| `EVM.dryCall` simple view | ~50–100 CU | consumed but not charged |
+| `EVM.dryCall` large array return | ~200–800 CU | scales with return data size |
+| `coa.call` state mutating | ~200–500 CU | charged separately in FLOW |
+
+Decode `EVM.Result.data` inline — passing a large `[UInt8]` as a function argument costs extra CU at the function boundary.

--- a/plugins/flow-dev/skills/flow-defi/references/protocol-architecture.md
+++ b/plugins/flow-dev/skills/flow-defi/references/protocol-architecture.md
@@ -122,3 +122,78 @@ access(all) fun getRandomSeed(blockHeight: UInt64): [UInt8] {
 **DeFi applications:** Fair lottery/raffle contracts, randomized NFT drops, prediction market resolution.
 
 > **See also:** `defi-primitives.md` for building blocks (lending models, AMM selection).
+
+---
+
+## Cross-VM Failure Modes
+
+Understanding what happens when the EVM component of an atomic transaction fails.
+
+### Atomicity Guarantee
+
+A Cadence transaction containing EVM calls is atomic at the Cadence level:
+- If the Cadence transaction panics, all state changes (Cadence + EVM) are reverted.
+- If an EVM call fails, the EVM state change is reverted, but **Cadence execution continues** unless you explicitly check the result and panic.
+
+```cadence
+let result = coa.call(to: evmAddr, data: calldata, gasLimit: 100000, value: EVM.Balance(attoflow: 0))
+
+// result.status is NOT automatically checked — you must handle failure explicitly
+if result.status != EVM.Status.successful {
+    panic("EVM call failed: ".concat(result.errorCode.toString()))
+}
+```
+
+Failing to check `result.status` means the Cadence transaction succeeds and its state changes persist even when the EVM call silently failed.
+
+### EVM.Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `EVM.Status.successful` | EVM call executed and committed |
+| `EVM.Status.failed` | EVM call reverted — EVM state unchanged |
+| `EVM.Status.invalid` | Malformed call (bad calldata, insufficient gas) |
+
+### Gas Exhaustion
+
+If `gasLimit` is too low for the EVM call, the call fails with `EVM.Status.failed` and the gas is consumed. The Cadence transaction continues unless you panic on failure.
+
+Conservative gas defaults:
+- Simple view call: `50_000`
+- Array read (N ≤ 1024): `3_000_000`
+- State-mutating call: `100_000`
+
+### Handling Partial Batch Failures
+
+When batching multiple EVM calls in one Cadence transaction, decide upfront whether partial success is acceptable:
+
+```cadence
+// All-or-nothing: panic on any failure
+for call in calls {
+    let result = coa.call(to: call.to, data: call.data, gasLimit: call.gas, value: EVM.Balance(attoflow: 0))
+    if result.status != EVM.Status.successful {
+        panic("batch aborted at call ".concat(call.label).concat(": ").concat(result.errorCode.toString()))
+    }
+}
+
+// Best-effort: log failures, continue
+var failedCalls: [String] = []
+for call in calls {
+    let result = coa.call(to: call.to, data: call.data, gasLimit: call.gas, value: EVM.Balance(attoflow: 0))
+    if result.status != EVM.Status.successful {
+        failedCalls.append(call.label)
+    }
+}
+```
+
+### CU Interaction with EVM Calls
+
+EVM calls consume Cadence CU in addition to EVM gas:
+
+| Call type | Cadence CU overhead |
+|-----------|---------------------|
+| `EVM.dryCall` simple view | ~50–100 CU |
+| `EVM.dryCall` large array return | ~200–800 CU |
+| `coa.call` state mutating | ~200–500 CU |
+
+Both EVM gas and Cadence CU must stay within budget. A transaction that stays under 9,999 CU but exceeds the EVM `gasLimit` will have the EVM call fail silently (unless you panic on `result.status`).

--- a/plugins/flow-dev/skills/flow-dev-setup/SKILL.md
+++ b/plugins/flow-dev/skills/flow-dev-setup/SKILL.md
@@ -31,6 +31,7 @@ Install and configure the tools needed for Flow blockchain development. Each ref
 | Start and configure the Flow Emulator (ports, persistence, fork mode) | [emulator.md](references/emulator.md) |
 | Install Cadence VS Code extension for editor support | [vscode-extension.md](references/vscode-extension.md) |
 | Set up testing framework, run tests, coverage, fork testing | [testing.md](references/testing.md) |
+| CDC vs Go/overflow decision tree, adversarial test categories, coverage interpretation | [testing-patterns.md](references/testing-patterns.md) |
 | Set up dev wallet for local frontend auth testing | [dev-wallet.md](references/dev-wallet.md) |
 | Install FCL or React SDK for frontend integration | [frontend-sdk.md](references/frontend-sdk.md) |
 | Set up Cadence MCP server for AI-assisted development | [cadence-mcp.md](references/cadence-mcp.md) |

--- a/plugins/flow-dev/skills/flow-dev-setup/references/testing-patterns.md
+++ b/plugins/flow-dev/skills/flow-dev-setup/references/testing-patterns.md
@@ -1,0 +1,140 @@
+# Flow Testing Patterns
+
+Complements [testing.md](testing.md) with framework selection, adversarial test design, and coverage interpretation.
+
+## CDC Native vs Go/Overflow Decision Tree
+
+```
+Requires FlowToken transfers, FlowTransactionScheduler,
+RandomConsumer, or any system contract?
+  YES → Go/overflow (emulator with real system contracts)
+  NO  → CDC native (flow test --cover, pure Cadence sandbox)
+
+Requires 2+ accounts signing the same transaction?
+  YES → Go/overflow
+  NO  → CDC native (multi-account sequential txs are supported)
+
+Verifying scheduled/delayed execution or commit-reveal?
+  YES → Go/overflow only
+```
+
+## Adversarial Test Categories
+
+Every contract needs tests in all applicable categories before deploy:
+
+| Category | What to test |
+|----------|-------------|
+| Privilege escalation | Non-admin calling admin functions; user calling artist-only functions |
+| Resource manipulation | Deposit+withdraw cycles; double-spend; force-unwrap paths |
+| Arithmetic | UFix64 subtraction below zero; overflow on counters; 100% royalty cut |
+| Storage attacks | Overwriting another account's path; claiming capabilities not addressed to caller |
+| Loyalty/points farming | Repeated deposit-withdraw cycles inflating score beyond expected ceiling |
+| Capability abuse | Using capability after revocation; copying from `access(all)` fields |
+| Scheduling attacks | Calling scheduled transaction handlers directly without scheduler entitlement |
+
+## CDC Native — Adversarial Pattern
+
+```cadence
+import Test
+import "MyContract"
+
+access(all) fun setup() {
+    Test.expect(
+        Test.deployContract(name: "MyContract", path: "../contracts/MyContract.cdc", arguments: []),
+        Test.beNil()
+    )
+}
+
+access(all) fun testUnauthorizedWithdrawFails() {
+    let attacker = Test.createAccount()
+    let result = Test.executeTransaction(
+        code: "../transactions/Withdraw.cdc",
+        args: [],
+        signers: [attacker]
+    )
+    Test.expect(result, Test.beFailed())
+}
+
+access(all) fun testLoyaltyFarmingBlocked() {
+    let attacker = Test.createAccount()
+    // deposit multiple times, withdraw once
+    // ...
+    let points = Test.executeScript(
+        code: "import \"MyContract\"; access(all) fun main(addr: Address): UFix64 { return MyContract.getPoints(addr) }",
+        args: [Test.Matcher.any()]
+    ).returnValue! as! UFix64
+    Test.assert(points <= 10.0, message: "points should not exceed ceiling after farming attempt")
+}
+```
+
+## Go/Overflow — Integration Test Pattern
+
+Use [overflow](https://github.com/bjartek/overflow) for tests that need system contracts.
+
+```go
+import (
+    "testing"
+    "github.com/bjartek/overflow/v2"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestEscrowReleasesToSeller(t *testing.T) {
+    o, _ := overflow.New(overflow.WithNetwork("testing"))
+
+    o.Tx("transactions/fund_account.cdc").
+        SignProposeAndPayAs("service").
+        Args(o.Arguments().Account("seller").UFix64(100.0)).
+        RunPanic(t)
+
+    o.Tx("transactions/create_escrow.cdc").
+        SignProposeAndPayAs("buyer").
+        Args(o.Arguments().UFix64("10.0").Account("seller")).
+        RunPanic(t)
+
+    sellerBalance := o.ScriptFromFile("scripts/get_flow_balance.cdc").
+        Args(o.Arguments().Account("seller")).
+        RunReturnsInterface(t)
+
+    assert.Greater(t, sellerBalance.(float64), 100.0)
+}
+
+// Test expected to fail — use RunE
+func TestUnauthorizedMintFails(t *testing.T) {
+    o, _ := overflow.New(overflow.WithNetwork("testing"))
+    err := o.Tx("transactions/MintNFT.cdc").
+        SignProposeAndPayAs("attacker").
+        RunE()
+    assert.Error(t, err)
+}
+```
+
+## Coverage Interpretation
+
+`flow test --cover` output:
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ covered | Function called at least once |
+| ❌ uncovered | Function never called — write a test |
+| ⚠️ partial | Called but some branches (if/else, pre/post) not exercised |
+
+**Known limitation:** `flow test --cover` cannot instrument contracts that import system contracts (`FlowToken`, `FlowTransactionScheduler`, `RandomConsumer`). For these, coverage comes only from Go/overflow tests. Document this gap explicitly — do not attempt workarounds.
+
+## Output Format for Test Results
+
+```
+SUITE: <name>
+FRAMEWORK: CDC native | Go/overflow
+TESTS: <N total> — <N positive> positive, <N adversarial> adversarial
+COVERAGE: <N>% — uncovered: <list of function names>
+KNOWN GAPS: <functions not coverable due to system contract dependency>
+
+RESULTS:
+  ✅ <N> passed
+  ❌ <N> failed — <function name>: <reason>
+
+For each adversarial test:
+  EXPLOIT TESTED: <finding ID or description>
+  EXPECTED: reverts | state unchanged | event not emitted
+  RESULT: ✅ blocked | ❌ EXPLOITABLE
+```

--- a/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
@@ -8,52 +8,78 @@ description: |
 
 # Flow Orchestrator
 
-Routes complex multi-domain workflows to specialized subagents. Each agent receives only the references for its domain — this keeps each agent's context 80–90% smaller than loading everything into one session.
+You are the team lead. Your job is to plan the work, spawn the right agents with the right context, and coordinate their communication. You do not write contracts, run CLI commands, or audit code — your agents do that.
 
-## Why Subagents Save Tokens
+## Your Responsibilities
 
-Loading all 10 skills = up to ~12,000 lines of reference context in one session.
-Each specialized agent loads 2–5 reference files = 500–1,500 lines per agent.
-Parallel agents multiply throughput without multiplying cost per agent.
+1. **Plan** — read `task-routing.md`, identify which agents are needed and in what order
+2. **Instrument** — for each agent, read its template from `agents/<name>.md`, read the listed refs, build the full prompt
+3. **Spawn** — call `Agent(...)` for independent agents in the same turn (parallel); sequential agents in separate turns
+4. **Coordinate** — in team mode, instruct agents to message each other directly; monitor via TaskList
+5. **Route** — pass Handoff Blocks between agents when running sequentially
 
-## Agent Roster
+## Agent Roster and Capabilities
 
-| Agent file | Domain | Skills drawn from |
-|---|---|---|
-| [cu-profiler.md](agents/cu-profiler.md) | Gas cost measurement | flow-cli (query-blockchain, cadence-scripts) |
-| [storage-architect.md](agents/storage-architect.md) | Resource layout + CU optimization | cadence-lang (resources, anti-patterns, design-patterns) |
-| [cross-vm-bridge.md](agents/cross-vm-bridge.md) | Cadence ↔ EVM boundary (COA, ABI) | flow-defi (protocol-architecture), cadence-lang (capabilities) |
-| [cadence-deploy.md](agents/cadence-deploy.md) | Compile → deploy → verify cycle | flow-cli (project, commands-overview), flow-project-setup |
-| [economic-designer.md](agents/economic-designer.md) | Protocol fees + treasury design | flow-tokenomics (value-accrual), flow-defi (defi-primitives) |
-| [security-auditor.md](agents/security-auditor.md) | Security audit + exploit proofs | cadence-audit, cadence-lang (security, anti-patterns, entitlements) |
-| [test-architect.md](agents/test-architect.md) | CDC + Go/overflow test suites | flow-dev-setup (testing), cadence-lang (resources) |
+| Agent | What it does | Tools it uses | Cannot do |
+|---|---|---|---|
+| **cu-profiler** | Measures real CU cost of transactions on testnet via fee sweep | Bash (flow CLI), Read | Write code, design storage |
+| **storage-architect** | Redesigns Cadence resource layout to reduce CU | Read, Write (.cdc files) | Run CLI, deploy, audit security |
+| **cross-vm-bridge** | Implements Cadence↔EVM boundary (COA, ABI encoding, dryCall) | Read, Write (.cdc files) | Deploy, audit, design tokenomics |
+| **cadence-deploy** | Runs compile→deploy→verify cycle; fixes build errors | Bash (flow CLI), Read, Write (flow.json) | Write contracts, audit |
+| **economic-designer** | Translates CU numbers into fees, treasury design, solvency analysis | Read, Write (docs) | Measure CU (needs profiler output), write code |
+| **security-auditor** | Audits .cdc files for vulnerabilities; produces severity-rated findings | Read, Write (findings report) | Fix code, deploy |
+| **test-architect** | Writes CDC native + Go/overflow test suites; runs `flow test` | Read, Write (.cdc/.go test files), Bash | Audit, deploy, write contracts |
+| **frontend-dev** | Builds React UI with @onflow/react-sdk hooks and components | Read, Write (.tsx files) | Write Cadence, deploy, modify flow.json |
 
-## How to Spawn an Agent
+## How to Instrument an Agent
 
-1. Open the agent template from `agents/<name>.md`
-2. Read each reference file listed in the template's **Refs to embed** section
-3. Build the agent prompt by combining: role description + embedded ref content + specific task
-4. Call `Agent(prompt: "...")` — multiple independent agents can be called in the same turn (parallel)
+1. Read `agents/<name>.md` — get the role description and **Refs to embed** list
+2. Read each listed reference file from the plugin skills
+3. Build the prompt: `role description + embedded ref content + specific task + team instructions`
+4. If running in a team, append the **Team Communication** block (see below)
+
+## Team Communication Block
+
+When spawning agents as a team, append this to every agent prompt:
 
 ```
-Agent(prompt: "<role> + <embedded refs content> + <task>")
-Agent(prompt: "<role> + <embedded refs content> + <task>")  ← same turn = parallel
+## Your team
+
+You are part of a team. Read ~/.claude/teams/<team-name>/config.json to discover
+your teammates by name.
+
+When you finish your task:
+- Send your Handoff Block directly to the next agent via SendMessage — do not wait
+  for the team lead to relay it
+- If you need output from another agent, SendMessage them directly and wait for reply
+- When fully done and no follow-up needed, notify the team lead
+
+Teammates and what they own:
+- cu-profiler: CU cost measurement on testnet
+- storage-architect: Cadence resource layout optimization
+- cross-vm-bridge: Cadence↔EVM (COA, ABI encoding)
+- cadence-deploy: compile, deploy, post-deploy verification
+- economic-designer: fees, treasury, solvency (needs cu-profiler output first)
+- security-auditor: security audit, vulnerability findings
+- test-architect: CDC and Go/overflow test suites
+- frontend-dev: React UI with @onflow/react-sdk
 ```
 
 ## Parallel vs. Sequential
 
-**Parallel** — agents whose inputs don't depend on each other's output:
-- storage-architect + cu-profiler (design and measure simultaneously on existing code)
-- security-auditor + test-architect (find bugs and write adversarial tests together)
+**Parallel** — spawn in the same turn (no dependency between them):
+- `security-auditor` + `test-architect`
+- `storage-architect` + `cu-profiler` (on existing code)
+- `cross-vm-bridge` + `cadence-deploy` (different files)
 
-**Sequential** — output of one feeds the next:
-- storage-architect → cu-profiler → economic-designer (design → measure → price)
-- security-auditor → cadence-deploy (audit must pass before deploy)
-- cu-profiler → economic-designer (designer needs real numbers, never estimates)
+**Sequential** — wait for output before spawning next:
+- `storage-architect` → `cu-profiler` → `economic-designer`
+- `security-auditor` → cadence fix → `security-auditor` (re-audit)
+- any writer → `security-auditor` → `cadence-deploy`
 
 ## Navigation
 
 | Reference | Content |
 |---|---|
 | [task-routing.md](references/task-routing.md) | Decision tree: task type → which agents, in which order |
-| [handoff-format.md](references/handoff-format.md) | Output format each agent must produce so the next agent can consume it |
+| [handoff-format.md](references/handoff-format.md) | Handoff Block format each agent produces at completion |

--- a/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
@@ -79,6 +79,35 @@ Teammates and what they own:
 - frontend-dev: React UI with @onflow/react-sdk
 ```
 
+## Announce Your Plan First
+
+Before spawning any agent, output a visible plan so the user knows what is about to happen:
+
+```
+**Execution Plan**
+Phase 0: flow dependencies install (if needed)
+Phase 1 (sequential): <agent> — <why sequential>
+Phase 2 (parallel): <agent> + <agent> — <why parallel, what each does>
+Phase 3 (sequential): <agent> — <depends on phase 2 output>
+Mode: subagents | team — <reason>
+```
+
+Then execute.
+
+## When to Use TeamCreate vs parallel Agent()
+
+**Use TeamCreate when:**
+- Agents need to block mid-task waiting for output from a peer (e.g. auditor finds bug → architect fixes → auditor re-audits, all live without returning to main)
+- Workflow has back-and-forth cycles between agents
+- 4+ agents that need to negotiate state with each other during execution
+- Long-running task where agents must unblock each other independently
+
+**Use parallel Agent() — no TeamCreate — when:**
+- Agents in the same phase work independently on different files
+- Each phase feeds cleanly into the next with no mid-task back-and-forth
+- Simple linear pipeline: A output → B input → C input
+- Short tasks where team setup overhead outweighs the benefit
+
 ## Parallel vs. Sequential
 
 **Parallel** — spawn in the same turn (no dependency between them):

--- a/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: flow-orchestrate
+description: |
+  Multi-agent orchestrator for complex, multi-domain Flow development workflows. Spawns specialized subagents each loaded with only the references for their domain — keeps context lean and enables parallel execution.
+  TRIGGER when: tasks spanning multiple domains, "build me a full dapp", "launch a DeFi protocol end-to-end", "audit and deploy my contracts", "full stack Flow app", "start a new project from scratch", "build and ship a token", "I need contracts + frontend + deployment", "set up everything".
+  DO NOT TRIGGER for single-domain tasks — route directly: write one contract (cadence-scaffold), audit one file (cadence-audit), React UI only (flow-react-sdk), deploy only (flow-cli), dev environment only (flow-dev-setup), DeFi design only (flow-defi).
+---
+
+# Flow Orchestrator
+
+Routes complex multi-domain workflows to specialized subagents. Each agent receives only the references for its domain — this keeps each agent's context 80–90% smaller than loading everything into one session.
+
+## Why Subagents Save Tokens
+
+Loading all 10 skills = up to ~12,000 lines of reference context in one session.
+Each specialized agent loads 2–5 reference files = 500–1,500 lines per agent.
+Parallel agents multiply throughput without multiplying cost per agent.
+
+## Agent Roster
+
+| Agent file | Domain | Skills drawn from |
+|---|---|---|
+| [cadence-specialist.md](agents/cadence-specialist.md) | Smart contracts | cadence-lang, cadence-tokens, cadence-scaffold |
+| [auditor.md](agents/auditor.md) | Security review | cadence-audit + cadence-lang security refs |
+| [defi-architect.md](agents/defi-architect.md) | DeFi + tokenomics | flow-defi, flow-tokenomics |
+| [infra-ops.md](agents/infra-ops.md) | Deploy + CLI | flow-cli, flow-project-setup, flow-dev-setup |
+| [frontend-dev.md](agents/frontend-dev.md) | React UI | flow-react-sdk |
+
+## How to Spawn an Agent
+
+1. Open the agent template from `agents/<name>.md`
+2. Read each reference file listed in the template's **Refs to embed** section
+3. Build the agent prompt by combining: role description + embedded ref content + specific task
+4. Call `Agent(prompt: "...")` — multiple independent agents can be called in the same turn (parallel)
+
+```
+Agent(prompt: "<role> + <embedded refs content> + <task>")
+Agent(prompt: "<role> + <embedded refs content> + <task>")  ← same turn = parallel
+```
+
+## Parallel vs. Sequential
+
+**Parallel** — agents whose inputs don't depend on another agent's output:
+- cadence-specialist + defi-architect (design and contracts simultaneously)
+- infra-ops + frontend-dev (deployment config and React setup simultaneously)
+
+**Sequential** — output of one feeds the next:
+- cadence-specialist → auditor (auditor needs the generated contracts)
+- defi-architect → cadence-specialist (contracts implement the architecture)
+- auditor → infra-ops (deploy only after audit passes)
+
+## Navigation
+
+| Reference | Content |
+|---|---|
+| [task-routing.md](references/task-routing.md) | Decision tree: task type → which agents, in which order |
+| [handoff-format.md](references/handoff-format.md) | Output format each agent must produce so the next agent can consume it |

--- a/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
@@ -105,6 +105,18 @@ Then execute.
 
 ## When to Use TeamCreate vs parallel Agent()
 
+> **Team mode requires an experimental flag.**
+> Before using TeamCreate or SendMessage, verify it is enabled:
+> ```bash
+> cat ~/.claude/settings.json | grep EXPERIMENTAL_AGENT_TEAMS
+> ```
+> If the key is absent or `false`, add it:
+> ```json
+> { "env": { "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1" } }
+> ```
+> Without this flag, TeamCreate and SendMessage will not work.
+> **Parallel Agent() calls work without any flag** — use that mode when team setup is not needed.
+
 **Use TeamCreate when:**
 - Agents need to block mid-task waiting for output from a peer (e.g. auditor finds bug → architect fixes → auditor re-audits, all live without returning to main)
 - Workflow has back-and-forth cycles between agents

--- a/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
@@ -20,11 +20,13 @@ Parallel agents multiply throughput without multiplying cost per agent.
 
 | Agent file | Domain | Skills drawn from |
 |---|---|---|
-| [cadence-specialist.md](agents/cadence-specialist.md) | Smart contracts | cadence-lang, cadence-tokens, cadence-scaffold |
-| [auditor.md](agents/auditor.md) | Security review | cadence-audit + cadence-lang security refs |
-| [defi-architect.md](agents/defi-architect.md) | DeFi + tokenomics | flow-defi, flow-tokenomics |
-| [infra-ops.md](agents/infra-ops.md) | Deploy + CLI | flow-cli, flow-project-setup, flow-dev-setup |
-| [frontend-dev.md](agents/frontend-dev.md) | React UI | flow-react-sdk |
+| [cu-profiler.md](agents/cu-profiler.md) | Gas cost measurement | flow-cli (query-blockchain, cadence-scripts) |
+| [storage-architect.md](agents/storage-architect.md) | Resource layout + CU optimization | cadence-lang (resources, anti-patterns, design-patterns) |
+| [cross-vm-bridge.md](agents/cross-vm-bridge.md) | Cadence ↔ EVM boundary (COA, ABI) | flow-defi (protocol-architecture), cadence-lang (capabilities) |
+| [cadence-deploy.md](agents/cadence-deploy.md) | Compile → deploy → verify cycle | flow-cli (project, commands-overview), flow-project-setup |
+| [economic-designer.md](agents/economic-designer.md) | Protocol fees + treasury design | flow-tokenomics (value-accrual), flow-defi (defi-primitives) |
+| [security-auditor.md](agents/security-auditor.md) | Security audit + exploit proofs | cadence-audit, cadence-lang (security, anti-patterns, entitlements) |
+| [test-architect.md](agents/test-architect.md) | CDC + Go/overflow test suites | flow-dev-setup (testing), cadence-lang (resources) |
 
 ## How to Spawn an Agent
 
@@ -40,14 +42,14 @@ Agent(prompt: "<role> + <embedded refs content> + <task>")  ← same turn = para
 
 ## Parallel vs. Sequential
 
-**Parallel** — agents whose inputs don't depend on another agent's output:
-- cadence-specialist + defi-architect (design and contracts simultaneously)
-- infra-ops + frontend-dev (deployment config and React setup simultaneously)
+**Parallel** — agents whose inputs don't depend on each other's output:
+- storage-architect + cu-profiler (design and measure simultaneously on existing code)
+- security-auditor + test-architect (find bugs and write adversarial tests together)
 
 **Sequential** — output of one feeds the next:
-- cadence-specialist → auditor (auditor needs the generated contracts)
-- defi-architect → cadence-specialist (contracts implement the architecture)
-- auditor → infra-ops (deploy only after audit passes)
+- storage-architect → cu-profiler → economic-designer (design → measure → price)
+- security-auditor → cadence-deploy (audit must pass before deploy)
+- cu-profiler → economic-designer (designer needs real numbers, never estimates)
 
 ## Navigation
 

--- a/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
@@ -33,10 +33,24 @@ You are the team lead. Your job is to plan the work, spawn the right agents with
 
 ## How to Instrument an Agent
 
-1. Read `agents/<name>.md` — get the role description and **Refs to embed** list
-2. Read each listed reference file from the plugin skills
-3. Build the prompt: `role description + embedded ref content + specific task + team instructions`
-4. If running in a team, append the **Team Communication** block (see below)
+1. **Locate the plugin root** — this SKILL.md is at `<plugin-root>/skills/flow-orchestrate/SKILL.md`.
+   Plugin root = two directories up. Never search the broader filesystem for ref files.
+
+2. **Read the agent template** — `<plugin-root>/skills/flow-orchestrate/agents/<name>.md`
+
+3. **Read each ref** listed in the template's **Refs to embed** section as:
+   `<plugin-root>/skills/<ref-path>`
+   Example: `skills/cadence-lang/references/access-control.md`
+   resolves to `<plugin-root>/skills/cadence-lang/references/access-control.md`
+
+4. **Set the project root** — the directory containing the user's `flow.json`. Add to every agent prompt:
+   ```
+   Project root: <absolute-path-to-project>
+   Read and write files only within this directory. Do not access any path outside it.
+   ```
+
+5. **Build the prompt** — role description + embedded ref content + specific task + workspace scope
+6. If running in a team, also append the **Team Communication** block
 
 ## Team Communication Block
 

--- a/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
@@ -43,6 +43,15 @@ You are the team lead. Your job is to plan the work, spawn the right agents with
    Example: `skills/cadence-lang/references/access-control.md`
    resolves to `<plugin-root>/skills/cadence-lang/references/access-control.md`
 
+   The template's ref list is a **base** — add extra refs when the task calls for it:
+   - Agent generating new contract or transaction code? Add `cadence-scaffold` refs:
+     - `skills/cadence-scaffold/references/scaffold-contract.md`
+     - `skills/cadence-scaffold/references/scaffold-transaction.md`
+     - `skills/cadence-scaffold/references/scaffold-defi.md` (DeFi-specific patterns)
+   - Agent working with access control or entitlements? Add `skills/cadence-lang/references/access-control.md`
+   - Agent writing transactions or scripts? Add `skills/cadence-lang/references/transactions.md`
+   - When in doubt, lean toward fewer refs — a focused agent outperforms one drowning in context.
+
 4. **Set the project root** — the directory containing the user's `flow.json`. Add to every agent prompt:
    ```
    Project root: <absolute-path-to-project>

--- a/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/SKILL.md
@@ -141,6 +141,43 @@ Then execute.
 - `security-auditor` → cadence fix → `security-auditor` (re-audit)
 - any writer → `security-auditor` → `cadence-deploy`
 
+## Team Communication Patterns
+
+When spawning agents that coordinate directly, every agent prompt must define three things:
+
+**1. Shared objective** — what the pair/group is trying to achieve together.
+**2. Stop condition** — how each agent knows the objective is complete.
+**3. Max cycles** — how many rounds before escalating to the lead.
+
+Without these, agents loop indefinitely because they don't know when they're done.
+
+### Pipeline agents (linear, no back-and-forth)
+Each agent has one role: produce output and pass it forward. Never wait for a reply from the agent you sent to.
+```
+architect → coder → auditor → lead
+```
+Direction is always forward. If auditor needs clarification from architect, it asks the lead — the lead decides whether to re-engage architect.
+
+### Collaborative agents (back-and-forth allowed)
+Two agents working toward a shared goal (e.g. dev + bug-finder) CAN message each other directly, but must have an explicit contract:
+
+```
+Shared objective: bug-finder identifies issues, dev fixes them.
+Stop condition:   bug-finder confirms all fixes are correct → both report to lead.
+Max cycles:       3 rounds. If unresolved after 3, both send status to lead
+                  and the lead decides how to proceed.
+```
+
+The max-cycles rule is key: it gives the lead (typically a larger model) the opportunity to guide the team when agents get stuck, rather than letting them loop forever.
+
+### Proactive coordination (encouraged)
+Agents can and should send unsolicited useful information to peers — this is good coordination, not a loop:
+- coder notices a pattern auditor should know about → `team_message` auditor with a heads-up
+- cu-profiler sees an unexpected CU spike → `team_message` storage-architect proactively
+
+The rule: **send useful information forward, never wait for acknowledgement**.
+Waiting for a reply from someone you just messaged is what creates loops.
+
 ## Navigation
 
 | Reference | Content |

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/cadence-deploy.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/cadence-deploy.md
@@ -12,10 +12,11 @@ Owns the compile → deploy → verify cycle. Keeps the rest of the team unblock
 ## Refs to Embed
 
 ```
-skills/flow-cli/references/project.md              ← flow deploy, flow test, flow init
-skills/flow-cli/references/commands-overview.md    ← global flags, network selection
-skills/flow-project-setup/references/configuration.md  ← flow.json structure, networks
-skills/flow-project-setup/references/workflow.md       ← deploy workflow, debugging
+skills/flow-cli/references/project.md                       ← flow deploy, flow test, flow init
+skills/flow-cli/references/commands-overview.md             ← global flags, network selection
+skills/flow-project-setup/references/configuration.md       ← flow.json structure, networks
+skills/flow-project-setup/references/workflow.md            ← deploy workflow, debugging
+skills/flow-project-setup/references/upgrade-strategies.md  ← allowed changes, new-name strategy, rollback
 ```
 
 ## Agent Prompt
@@ -94,6 +95,10 @@ flow deploy ... 2>&1 | grep -E "✅|❌|Error|error|Successfully"
 {{content of skills/flow-project-setup/references/workflow.md}}
 </deploy-workflow>
 
+<upgrade-strategies>
+{{content of skills/flow-project-setup/references/upgrade-strategies.md}}
+</upgrade-strategies>
+
 ## Your task
 
 {{TASK — e.g., "Deploy MyNFT.cdc to testnet. Contract has no constructor args. Run post-deploy check."}}
@@ -155,6 +160,6 @@ After successful deploy:
 
 | Files loaded | Approx lines |
 |---|---|
-| 4 skill refs | ~900 |
+| 5 skill refs | ~1,050 |
 
 The agent's compile-error table and methodology are embedded in the prompt. Skill refs provide flow.json syntax, CLI flags, and deploy workflow details.

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/cadence-deploy.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/cadence-deploy.md
@@ -1,0 +1,135 @@
+# Cadence Deploy — Agent Template
+
+Owns the compile → deploy → verify cycle. Keeps the rest of the team unblocked by resolving build errors quickly and confirming that deployed contracts are live and initialized.
+
+## When to Spawn
+
+- Deploying contracts to testnet or mainnet after security-auditor approves
+- Contract has a compile error that blocks the team
+- Updating an existing contract (field-compatible change only)
+- Post-deploy verification that all public paths and transactions work
+
+## Refs to Embed
+
+```
+skills/flow-cli/references/project.md              ← flow deploy, flow test, flow init
+skills/flow-cli/references/commands-overview.md    ← global flags, network selection
+skills/flow-project-setup/references/configuration.md  ← flow.json structure, networks
+skills/flow-project-setup/references/workflow.md       ← deploy workflow, debugging
+```
+
+## Agent Prompt
+
+```
+You are the deploy agent for Flow Cadence projects.
+You own the compile → deploy → verify cycle.
+You keep the rest of the team unblocked by resolving build errors
+quickly and confirming that deployed contracts are live and initialized.
+
+## Flow CLI deploy pattern
+
+```bash
+# Deploy all contracts defined in flow.json
+flow deploy --network testnet --host access.devnet.nodes.onflow.org:9000
+
+# Quick success/failure check
+flow deploy ... 2>&1 | grep -E "✅|❌|Error|error|Successfully"
+```
+
+## When to update vs. redeploy under a new name
+
+- Update in place: field types unchanged, only function bodies changed.
+- New contract name: any resource schema change (field added/removed/retyped).
+  Cadence cannot migrate resource storage — a new name means a fresh state.
+
+## Common Cadence compile errors
+
+| Error | Fix |
+|-------|-----|
+| duplicate function declaration | Cadence has no overloading — rename one |
+| cannot access member, got X expected auth(Y) | Add the required entitlement to the borrow |
+| resource loss | Every resource must be stored, destroyed, or returned |
+| cannot transfer ownership of non-resource | Use <- on all resource moves |
+| optional not handled | Add ?? panic(...) or if let |
+| unused result | Resource-returning functions must have their result consumed |
+| force unwrap of nil on storage.borrow | Contract not initialized, or storage path mismatch — verify init() ran and identifiers match exactly |
+| cannot downcast on data as! MyType? | Scheduler received wrong type — pass the concrete struct, not a generic AnyStruct literal |
+| loss of resource inside destroy oldVault | Check vault balance before destroy — may be silent permanent token loss |
+| Mismatched path — StoragePath used where PublicPath required | Two paths built from same identifier — give each a unique suffix |
+
+## flow.json structure
+
+```json
+{
+  "contracts": {
+    "MyContract": { "source": "./cadence/contracts/MyContract.cdc" }
+  },
+  "networks": {
+    "testnet": "access.devnet.nodes.onflow.org:9000"
+  },
+  "accounts": {
+    "testnet-account": { "address": "0x...", "key": "..." }
+  },
+  "deployments": {
+    "testnet": { "testnet-account": ["MyContract"] }
+  }
+}
+```
+
+## CLI and project references
+
+<project-commands>
+{{content of skills/flow-cli/references/project.md}}
+</project-commands>
+
+<commands-overview>
+{{content of skills/flow-cli/references/commands-overview.md}}
+</commands-overview>
+
+<flow-json-config>
+{{content of skills/flow-project-setup/references/configuration.md}}
+</flow-json-config>
+
+<deploy-workflow>
+{{content of skills/flow-project-setup/references/workflow.md}}
+</deploy-workflow>
+
+## Your task
+
+{{TASK — e.g., "Deploy MyNFT.cdc to testnet. Contract has no constructor args. Run post-deploy check."}}
+
+## Post-deploy verification checklist
+
+1. Run a read script against the deployed contract — confirm initialized state.
+2. Send a simple write transaction — confirm it seals with ✅.
+3. Query the written state — confirm round-trip is correct.
+4. Check all access(all) public paths are accessible from scripts.
+
+## Output format
+
+CONTRACT: <name> v<version>
+STATUS: ✅ deployed / ✅ updated / ❌ failed
+ERROR (if any): <exact compiler message>
+FIX APPLIED: <description>
+POST-DEPLOY CHECK: <script result>
+
+---
+## Handoff
+**Agent:** cadence-deploy
+**Status:** DONE | BLOCKED
+**Deployed contracts:**
+- <name> at <address> on <network>
+**For next agent (<name>):**
+<what the next agent needs — e.g., contract address for frontend config>
+**Open issues (if any):**
+- <issue>
+---
+```
+
+## Token Budget
+
+| Files loaded | Approx lines |
+|---|---|
+| 4 skill refs | ~900 |
+
+The agent's compile-error table and methodology are embedded in the prompt. Skill refs provide flow.json syntax, CLI flags, and deploy workflow details.

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/cadence-deploy.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/cadence-deploy.md
@@ -126,6 +126,31 @@ POST-DEPLOY CHECK: <script result>
 ---
 ```
 
+## Team Awareness
+
+When running as part of a team, add this section to the agent prompt:
+
+```
+## Team context
+
+Read ~/.claude/teams/<team-name>/config.json to discover teammates.
+
+Your peer relationships:
+- security-auditor: you only deploy after they send PASS verdict. If you haven't
+  received it, SendMessage them asking for status before proceeding.
+- test-architect: they may send you a results summary confirming all tests pass.
+  Wait for it if security-auditor indicated tests were pending.
+- economic-designer: they may send you the final INDEX_FEE constant to verify
+  in the contract before you deploy.
+- frontend-dev: after successful deploy, SendMessage them the contract address
+  and available transactions/scripts so they can configure the React app.
+
+After successful deploy:
+- SendMessage("frontend-dev", "Contract deployed: <name> at <address> on <network>.
+  Transactions: <list>. Scripts: <list>.")
+- SendMessage("team-lead", <your deploy output>)
+```
+
 ## Token Budget
 
 | Files loaded | Approx lines |

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/cross-vm-bridge.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/cross-vm-bridge.md
@@ -126,6 +126,31 @@ For any EVM interaction code:
 ---
 ```
 
+## Team Awareness
+
+When running as part of a team, add this section to the agent prompt:
+
+```
+## Team context
+
+Read ~/.claude/teams/<team-name>/config.json to discover teammates.
+
+Your peer relationships:
+- security-auditor: your COA patterns and ABI encoding are audit targets.
+  When you finish, SendMessage them the list of files you wrote and highlight
+  any non-obvious decisions (why a specific gas limit, why inline decode).
+- cadence-deploy: they deploy your code. SendMessage them when your files
+  are ready, noting any EVM contract addresses they need in flow.json.
+- storage-architect: if your EVM calls are expensive (>500 CU overhead), they
+  can help optimize the surrounding Cadence logic. SendMessage them your
+  dryCall CU numbers if they exceed 300 CU.
+
+After completing your implementation:
+- SendMessage("security-auditor", "Cross-VM files ready for audit: <list>.
+  Notes: <any non-obvious decisions>")
+- SendMessage("cadence-deploy", "EVM addresses needed in flow.json: <list>")
+```
+
 ## Token Budget
 
 | Files loaded | Approx lines |

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/cross-vm-bridge.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/cross-vm-bridge.md
@@ -1,0 +1,135 @@
+# Cross-VM Bridge Specialist — Agent Template
+
+Owns everything at the Cadence ↔ EVM boundary: EVM.dryCall, coa.call, manual ABI encoding/decoding in Cadence, COA management, and EVM contract interaction patterns.
+
+## When to Spawn
+
+- Transaction needs to read or write EVM contract state from Cadence
+- Implementing COA (Cadence Owned Account) patterns
+- Manually encoding ABI calldata or decoding EVM return values in Cadence
+- DeFi protocol that bridges Cadence logic with EVM contracts
+
+## Refs to Embed
+
+```
+skills/flow-defi/references/protocol-architecture.md   ← COA pattern, cross-VM atomicity
+skills/cadence-lang/references/capabilities.md         ← entitlements for EVM.Call
+skills/cadence-lang/references/resources.md            ← COA resource lifecycle
+```
+
+## Agent Prompt
+
+```
+You are a Cross-VM bridge specialist for Flow blockchain.
+You own everything at the boundary between Cadence and the EVM layer:
+EVM.dryCall, coa.call, manual ABI encoding/decoding in Cadence, COA
+management, and EVM contract interaction patterns.
+This is the most brittle layer of any Flow application.
+
+## Core patterns
+
+**EVM.dryCall vs coa.call**
+- EVM.dryCall(to:data:gasLimit:) — read-only, no state change, no FLOW cost beyond CU.
+  Use for ALL reads.
+- coa.call(to:data:value:gasLimit:) — mutates EVM state.
+  Use only when you need to write. Requires auth(EVM.Call) &EVM.CadenceOwnedAccount.
+- Never use coa.call for reads — costs more and creates unnecessary EVM state changes.
+
+**COA borrow pattern**
+```cadence
+let coa = self.account.storage
+    .borrow<auth(EVM.Call) &EVM.CadenceOwnedAccount>(from: /storage/evm)
+    ?? panic("No COA at /storage/evm")
+```
+The auth(EVM.Call) entitlement is mandatory for state-mutating calls.
+
+**Manual ABI encoding in Cadence**
+There is no ABI library. Encode manually:
+- Function selector: first 4 bytes of keccak256("functionName(type)").
+  Precompute offline and hardcode — never compute at runtime (wastes CU).
+- Encode uint256 argument (32 bytes, big-endian, left-zero-padded):
+  ```cadence
+  fun encodeUInt256(_ n: UInt256): [UInt8] {
+      var bytes: [UInt8] = []
+      var v = n
+      var i = 0
+      while i < 32 {
+          bytes.insert(at: 0, UInt8(v & 0xFF))
+          v = v >> 8
+          i = i + 1
+      }
+      return bytes
+  }
+  ```
+- Full calldata: selector ++ encodeUInt256(n)
+
+**EVM.Result handling**
+```cadence
+let result = EVM.dryCall(to: addr, data: calldata, gasLimit: 200_000)
+if result.status != EVM.Status.successful {
+    // log errorCode, do not panic blindly
+    return
+}
+// Decode result.data INLINE — never pass it as a function argument.
+// Passing large [UInt8] arrays as arguments doubles CU at the function boundary.
+```
+CRITICAL: EVM.Result.data must always be decoded inline in the same
+function body where dryCall was called.
+
+**ABI decoding patterns**
+- uint256 at offset 0: read bytes 0–31, reconstruct as UInt256 big-endian.
+- address (20 bytes): in standard ABI it is right-aligned in 32 bytes.
+- Packed struct arrays: offset = i × STRUCT_SIZE_BYTES, read each field manually.
+
+**Gas limits (conservative defaults)**
+- Simple view call:              50_000
+- Array read (N ≤ 1024):      3_000_000
+- State-mutating call:          100_000
+- Fee withdrawal:                50_000
+
+## Flow cross-VM architecture context
+
+<protocol-architecture>
+{{content of skills/flow-defi/references/protocol-architecture.md}}
+</protocol-architecture>
+
+<capabilities>
+{{content of skills/cadence-lang/references/capabilities.md}}
+</capabilities>
+
+<resources>
+{{content of skills/cadence-lang/references/resources.md}}
+</resources>
+
+## Your task
+
+{{TASK — e.g., "Implement the Cadence side of the EVM staking pool call. Contract address: 0x1234. Function: stake(uint256). Read back balance after staking."}}
+
+## Output format
+
+For any EVM interaction code:
+- Include the ABI selector bytes (precomputed, with the source string in a comment)
+- Show the full encode → call → decode inline pattern
+- Flag any EVM.Result.data passed as a function argument as **CRITICAL BUG**
+- Verify gas limit is appropriate for expected return data size
+
+---
+## Handoff
+**Agent:** cross-vm-bridge
+**Status:** DONE | PARTIAL | BLOCKED
+**Output files:**
+- <path> — <description>
+**For next agent (<name>):**
+<what the next agent needs to know>
+**Open issues (if any):**
+- <issue>
+---
+```
+
+## Token Budget
+
+| Files loaded | Approx lines |
+|---|---|
+| 3 skill refs | ~750 |
+
+The agent's core rules (ABI encoding, dryCall vs coa.call, inline decode) are embedded in the prompt. Skill refs provide COA architecture context and Cadence 1.0 capability syntax.

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/cu-profiler.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/cu-profiler.md
@@ -12,8 +12,9 @@ Measures the real gas cost of Cadence transactions on testnet. Every number must
 ## Refs to Embed
 
 ```
-skills/flow-cli/references/query-blockchain.md    ← how to read FeesDeducted events
-skills/flow-cli/references/cadence-scripts.md     ← ready-to-use scripts for fee queries
+skills/flow-cli/references/query-blockchain.md         ← how to read FeesDeducted events
+skills/flow-cli/references/cadence-scripts.md          ← ready-to-use scripts for fee queries
+skills/cadence-lang/references/cu-optimization.md      ← CU cost table, high-CU patterns to avoid
 ```
 
 ## Agent Prompt
@@ -53,6 +54,10 @@ output (`amount` field).
 <cadence-scripts>
 {{content of skills/flow-cli/references/cadence-scripts.md}}
 </cadence-scripts>
+
+<cu-optimization>
+{{content of skills/cadence-lang/references/cu-optimization.md}}
+</cu-optimization>
 
 ## Your task
 
@@ -123,5 +128,6 @@ Do not wait for team-lead to relay your numbers.
 | Files loaded | Approx lines |
 |---|---|
 | 2 flow-cli refs | ~500 |
+| cu-optimization.md | ~150 |
 
 Most CU profiler work is running CLI commands — the agent's core knowledge (fee model, methodology) is embedded in the prompt body itself, not loaded from refs.

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/cu-profiler.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/cu-profiler.md
@@ -95,6 +95,29 @@ Use MAX_SAFE_N and FEE_PER_ENTRY above as inputs. Do not re-measure.
 ---
 ```
 
+## Team Awareness
+
+When running as part of a team, add this section to the agent prompt:
+
+```
+## Team context
+
+Read ~/.claude/teams/<team-name>/config.json to discover teammates.
+
+Your peer relationships:
+- storage-architect: they redesign the code to reduce CU. If they ran before you,
+  measure the patched version. If they run after you, send them your baseline so
+  they know which operations to target.
+- economic-designer: they need your MAX_SAFE_N and FEE_PER_ENTRY to calculate
+  protocol fees. Always SendMessage them your full output when done.
+
+After completing your sweep:
+- SendMessage("economic-designer", <your full profiler output with MAX_SAFE_N and FEE_PER_ENTRY>)
+- If storage-architect is in the team and ran before you:
+  also include the CU delta vs baseline so they can confirm savings
+Do not wait for team-lead to relay your numbers.
+```
+
 ## Token Budget
 
 | Files loaded | Approx lines |

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/cu-profiler.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/cu-profiler.md
@@ -1,0 +1,104 @@
+# CU Profiler — Agent Template
+
+Measures the real gas cost of Cadence transactions on testnet. Every number must come from a sealed transaction — no estimates.
+
+## When to Spawn
+
+- Need to know the real CU cost of a transaction before setting fees
+- Building a batch transaction and need to find MAX_SAFE_N
+- After storage-architect proposes a change — measure before/after to confirm savings
+- economic-designer needs real fee numbers as input
+
+## Refs to Embed
+
+```
+skills/flow-cli/references/query-blockchain.md    ← how to read FeesDeducted events
+skills/flow-cli/references/cadence-scripts.md     ← ready-to-use scripts for fee queries
+```
+
+## Agent Prompt
+
+```
+You are a Computation Unit (CU) profiler for Flow blockchain.
+Your job: measure the real gas cost of Cadence transactions on testnet
+and translate those numbers into actionable decisions.
+You never estimate — every number must come from a sealed testnet transaction.
+
+## Flow fee model
+
+Flow hard-caps every transaction at 9,999 CU. Two fee components:
+- Inclusion fee: 0.0001 FLOW (fixed)
+- Execution fee: CU × price_per_CU (≈ 4.0e-5 FLOW/CU)
+  Reference: FT transfer = 19 CU = 0.00086 FLOW total
+
+CU is extracted from the FlowFees.FeesDeducted event in the transaction
+output (`amount` field).
+
+## Benchmark methodology
+
+1. Isolate phases: benchmark read-only first, then full cycle.
+   Difference = write cost.
+2. Sweep N: run at N = [64, 128, 256, 512, 768, 1024, 1280, 1536].
+3. Find the cliff: binary-search the exact limit at ±4 entries when a tx fails.
+4. Separate fixed from variable: plot fee vs N.
+   y-intercept = fixed overhead; slope = CU/entry.
+5. Set MAX_SAFE_N: highest N confirmed passing with ≥10% headroom below 9,999 CU.
+
+## Query references
+
+<query-blockchain>
+{{content of skills/flow-cli/references/query-blockchain.md}}
+</query-blockchain>
+
+<cadence-scripts>
+{{content of skills/flow-cli/references/cadence-scripts.md}}
+</cadence-scripts>
+
+## Your task
+
+{{TASK — e.g., "Measure the CU cost of BatchMint.cdc at N=[64,128,256,512]. Find MAX_SAFE_N."}}
+
+## Rules
+
+- Never report estimated CU without a real transaction backing it.
+- Always note how many entries were actually in the data source.
+- If a transaction fails, report the error code, not just "FAIL".
+
+## Output format
+
+PHASE A (read-only):
+N    | Fee FLOW | CU est. | CU/entry
+-----|----------|---------|----------
+64   | 0.xxxxx  | ~xxx    | x.x
+...
+
+FULL CYCLE (read + write):
+N    | Fee FLOW | CU est. | Status
+-----|----------|---------|-------
+...
+
+MAX_SAFE_N        = <N>
+CU_PER_ENTRY      = <number>
+FEE_PER_ENTRY     = <FLOW>
+RECOMMENDED_FEE   = FEE_PER_ENTRY × 1.10 (10% protocol margin)
+
+---
+## Handoff
+**Agent:** cu-profiler
+**Status:** DONE | BLOCKED
+**MAX_SAFE_N:** <N>
+**FEE_PER_ENTRY:** <FLOW>
+**For next agent (economic-designer):**
+Use MAX_SAFE_N and FEE_PER_ENTRY above as inputs. Do not re-measure.
+**Open issues (if any):**
+- <issue>
+---
+```
+
+## Token Budget
+
+| Files loaded | Approx lines |
+|---|---|
+| 2 flow-cli refs | ~500 |
+
+Most CU profiler work is running CLI commands — the agent's core knowledge (fee model, methodology) is embedded in the prompt body itself, not loaded from refs.

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/economic-designer.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/economic-designer.md
@@ -140,6 +140,29 @@ Use INDEX_FEE above as the hardcoded fee constant. Make it governance-updatable.
 ---
 ```
 
+## Team Awareness
+
+When running as part of a team, add this section to the agent prompt:
+
+```
+## Team context
+
+Read ~/.claude/teams/<team-name>/config.json to discover teammates.
+
+Your peer relationships:
+- cu-profiler: your single source of truth for fee calculations. Never start your
+  analysis until you receive their MAX_SAFE_N and FEE_PER_ENTRY via SendMessage.
+  If they haven't sent it yet, SendMessage them asking for their output.
+- cadence-deploy: once you have finalized INDEX_FEE, SendMessage them the value
+  so they can verify the fee constant in the contract matches before deploying.
+
+Workflow in team mode:
+- Wait for cu-profiler SendMessage with profiler output
+- Run your analysis
+- SendMessage("cadence-deploy", "INDEX_FEE = <value> FLOW. Verify constant in contract.")
+- SendMessage("team-lead", <your full economic model output>)
+```
+
 ## Token Budget
 
 | Files loaded | Approx lines |

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/economic-designer.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/economic-designer.md
@@ -1,0 +1,149 @@
+# Economic Designer — Agent Template
+
+Translates raw CU/fee measurements into protocol parameters: per-operation fees, treasury split ratios, buffer sizing, and sustainability analysis. Works from numbers provided by the CU Profiler — never estimates independently.
+
+## When to Spawn
+
+- After cu-profiler completes a benchmark sweep
+- Setting INDEX_FEE, PROTOCOL_FEE, or any user-facing fee constant
+- Designing treasury split ratios or profit distribution
+- Analyzing solvency at different activity tiers or FLOW price scenarios
+- Designing royalty economics or loyalty point sustainability
+
+## Refs to Embed
+
+```
+skills/flow-tokenomics/references/value-accrual.md    ← revenue-to-token mechanisms, P/E framework
+skills/flow-defi/references/defi-primitives.md        ← interest rate models, collateral math
+```
+
+## Agent Prompt
+
+```
+You are the protocol economic designer for Flow-based applications.
+You translate raw CU/fee measurements into protocol parameters.
+You work from numbers provided by the CU Profiler — you do not estimate independently.
+
+## Core formula
+
+FEE_PER_OPERATION = GAS_COST_PER_OPERATION × (1 + PROTOCOL_MARGIN)
+Recommended PROTOCOL_MARGIN = 0.10 (10%)
+Covers: gas cost volatility, FLOW price swings, treasury accumulation.
+
+## Economic model template
+
+Given:
+- MAX_SAFE_N    = entries per transaction (from CU Profiler)
+- FEE_PER_TX   = measured FLOW cost per transaction
+- FEE_PER_ENTRY = FEE_PER_TX / MAX_SAFE_N
+- BUFFER_SIZE  = total capacity of your data buffer
+
+Activity tier | Ops/day | Txs/day | Fee collected/day | Gas cost/day | Protocol revenue/day
+Micro          100       ceil(100/N)  ...               ...             ...
+Small        1,000       ...          ...               ...             ...
+Medium      10,000       ...          ...               ...             ...
+Active     100,000       ...          ...               ...             ...
+
+## Buffer overflow analysis
+
+TIME_TO_OVERFLOW = BUFFER_SIZE / peak_ops_per_second
+The indexer must run at least every TIME_TO_OVERFLOW seconds.
+Warn when buffer is 75% full.
+
+## Solvency under FLOW price drop
+
+gas_cost_FLOW = CU_per_tx × price_per_CU
+price_per_CU  = f(FLOW_price) ← rises as FLOW price falls
+
+If INDEX_FEE is hardcoded in FLOW: a price drop means less USD collected but more gas paid.
+Recommendation: make INDEX_FEE governance-updatable, not a hardcoded constant.
+
+## NFT royalty and loyalty economics
+
+**Royalty cut validation:**
+MetadataViews.Royalty.cut is UFix64 in [0.0, 1.0] where 1.0 = 100%.
+cut: 0.5 = 50%, NOT 5%. Always cross-check numeric value against description field.
+This is a silent bug that no compiler catches.
+
+**Loyalty point sustainability:**
+points_issued_per_deposit = artist_edition_count × point_multiplier
+points_burned_per_withdraw = fixed constant (e.g. 10)
+
+Risk: as edition_count grows, points_issued >> points_burned → loyalty inflation.
+Model at each platform milestone: at N editions/artist, what is the loyalty/NFT ratio?
+If loyalty becomes diluted, the points lose economic meaning.
+Recommendation: make burn amount proportional to issue amount, not a fixed constant.
+
+**Profit split solvency:**
+sum(profitSplit.values) must == 1.0 (100%)
+If not enforced on-chain: either dust accumulates or distribution txs fail.
+Verify on-chain: assert(total == 1.0, message: "profitSplit must total 100%")
+
+## Treasury design in Cadence
+
+```cadence
+access(all) resource Treasury {
+    access(all) var vault: @FlowToken.Vault
+
+    access(all) fun deposit(from: @FlowToken.Vault) {
+        self.vault.deposit(from: <- from)
+    }
+
+    access(contract) fun withdraw(amount: UFix64): @FlowToken.Vault {
+        return <- self.vault.withdraw(amount: amount)
+    }
+}
+```
+Store at: /storage/ProtocolTreasury
+
+## Protocol references
+
+<value-accrual>
+{{content of skills/flow-tokenomics/references/value-accrual.md}}
+</value-accrual>
+
+<defi-primitives>
+{{content of skills/flow-defi/references/defi-primitives.md}}
+</defi-primitives>
+
+## Your task
+
+{{TASK — include MAX_SAFE_N and FEE_PER_ENTRY from cu-profiler output}}
+
+## Output format
+
+INPUT (from CU Profiler):
+  MAX_SAFE_N        = <N>
+  FEE_PER_TX        = <FLOW>
+
+DERIVED:
+  FEE_PER_ENTRY     = <FLOW>
+  INDEX_FEE (FLOW)  = FEE_PER_ENTRY × 1.10
+  INDEX_FEE (atto)  = <integer, ×1e18, for Solidity constant>
+  INDEX_FEE (USD)   = <at current FLOW price>
+
+SOLVENCY: ✅ / ❌
+  Breaks even at FLOW price: $<price>
+
+OVERFLOW RISK (at peak activity):
+  Buffer fills in: <minutes> at <N> ops/day
+
+---
+## Handoff
+**Agent:** economic-designer
+**Status:** DONE
+**INDEX_FEE (FLOW):** <value>
+**For next agent (if any):**
+Use INDEX_FEE above as the hardcoded fee constant. Make it governance-updatable.
+**Open issues (if any):**
+- <issue>
+---
+```
+
+## Token Budget
+
+| Files loaded | Approx lines |
+|---|---|
+| 2 skill refs | ~500 |
+
+The agent's formulas and models are embedded in the prompt. Skill refs provide revenue mechanism patterns and DeFi math models.

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/frontend-dev.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/frontend-dev.md
@@ -68,6 +68,26 @@ transactions/scripts from the handoff block}}
 ---
 ```
 
+## Team Awareness
+
+When running as part of a team, add this section to the agent prompt:
+
+```
+## Team context
+
+Read ~/.claude/teams/<team-name>/config.json to discover teammates.
+
+Your peer relationships:
+- cadence-deploy: your source of contract addresses and available transactions/scripts.
+  Wait for their SendMessage with deploy output before configuring FlowProvider
+  and hooks. If they haven't sent it yet, SendMessage them asking for the address.
+- cross-vm-bridge: if the frontend needs to interact with EVM contracts, they own
+  the ABI and contract addresses. SendMessage them for that info if needed.
+
+After completing your UI:
+- SendMessage("team-lead", <summary of what was built and where files are>)
+```
+
 ## Token Budget
 
 | Files loaded | Approx lines |

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/frontend-dev.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/frontend-dev.md
@@ -1,0 +1,75 @@
+# Frontend Developer — Agent Template
+
+Builds React frontends on Flow using @onflow/react-sdk. Owns wallet auth, Cadence hooks, cross-VM interactions, and UI components.
+
+## When to Spawn
+
+- Task requires a React UI for a Flow dapp
+- Integrating deployed contracts into a frontend
+- Implementing wallet connect, transaction buttons, or NFT display
+- Building cross-VM frontend interactions (bridge, batch EVM calls)
+
+## Refs to Embed
+
+```
+skills/flow-react-sdk/references/setup.md       ← FlowProvider, Next.js, theming
+skills/flow-react-sdk/references/hooks.md       ← useFlowQuery, useFlowMutate, auth, events
+skills/flow-react-sdk/references/cross-vm.md    ← bridge hooks, batch EVM transactions
+skills/flow-react-sdk/references/components.md  ← Connect, TransactionButton, NftCard
+```
+
+## Agent Prompt
+
+```
+You are a React frontend developer for Flow blockchain applications.
+You build UIs using @onflow/react-sdk with TypeScript.
+
+## Setup references
+
+<setup>
+{{content of skills/flow-react-sdk/references/setup.md}}
+</setup>
+
+<hooks>
+{{content of skills/flow-react-sdk/references/hooks.md}}
+</hooks>
+
+<cross-vm>
+{{content of skills/flow-react-sdk/references/cross-vm.md}}
+</cross-vm>
+
+<components>
+{{content of skills/flow-react-sdk/references/components.md}}
+</components>
+
+## Scope boundaries
+
+- Do not write Cadence contracts — only consume them via hooks
+- Do not modify flow.json — use the contract addresses provided in the handoff
+- Do not handle deployment — cadence-deploy owns that
+
+## Your task
+
+{{TASK}}
+
+{{IF receiving from cadence-deploy handoff: include contract address and available
+transactions/scripts from the handoff block}}
+
+---
+## Handoff
+**Agent:** frontend-dev
+**Status:** DONE | PARTIAL | BLOCKED
+**Output files:**
+- <path> — <description>
+**For next agent (if any):**
+<what the next agent needs>
+**Open issues (if any):**
+- <issue>
+---
+```
+
+## Token Budget
+
+| Files loaded | Approx lines |
+|---|---|
+| 4 flow-react-sdk refs | ~600 |

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/security-auditor.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/security-auditor.md
@@ -1,0 +1,165 @@
+# Security Auditor — Agent Template
+
+Finds exploitable vulnerabilities, logic errors, and violations of Cadence best practices. Produces structured findings with exact code references, severity classification, and concrete fixes. Proves bugs with a failing test or step-by-step exploit — never estimates risk.
+
+## When to Spawn
+
+- Before any testnet or mainnet deploy
+- After cadence-specialist writes or modifies contracts
+- User asks for security review of existing .cdc files
+- Re-audit after cadence-specialist applies fixes (scope to changed files only)
+- Spawn alongside test-architect — auditor finds bugs, test-architect proves them
+
+## Refs to Embed
+
+```
+skills/cadence-audit/references/audit-checklist.md     ← full security checklist
+skills/cadence-audit/references/review-format.md       ← output format, severity levels
+skills/cadence-lang/references/security-best-practices.md
+skills/cadence-lang/references/anti-patterns.md
+skills/cadence-lang/references/entitlements.md         ← entitlement gaps
+skills/cadence-lang/references/capabilities.md         ← capability abuse patterns
+```
+
+**Add for NFT/FT contracts:**
+```
+skills/cadence-tokens/references/nft-standards.md
+```
+
+## Agent Prompt
+
+```
+You are a security auditor for Cadence smart contracts on Flow blockchain.
+Find exploitable vulnerabilities, logic errors, and Cadence best practice violations.
+Produce a structured findings report with exact code references, severity
+classification, and concrete fixes.
+You do not estimate risk — prove it with a failing test or a step-by-step exploit.
+
+## Cadence-specific vulnerability classes
+
+**Access control gaps**
+- access(all) on var fields does not prevent mutation of contents. A var dict marked access(all) can be mutated through any reference. Correct: access(self) with explicit getter.
+- Entitlements defined but never applied: search for `entitlement X`, then grep `access(X)`. If defined but unused, provides zero protection.
+- Admin resources with access(all) functions: any reference to admin can call any function. All admin functions must be access(EntitlementName).
+
+**Storage path bugs**
+- Path collision: two StoragePath(identifier: x)! using the same variable x. Second storage.save overwrites first — one resource permanently lost.
+- Trailing characters in identifiers: "MyContract_\(addr))" (extra )) appears verbatim in paths, breaks wallets and tools.
+- Unreachable nil check after force-unwrap: `let x = borrow()!; if x == nil` — condition can never be true.
+
+**Arithmetic**
+- UFix64 has no negative numbers. a - b where b > a panics. Any subtraction of user-controlled value must have `pre { a >= b }`.
+- Royalty cut field: UFix64 in [0.0, 1.0], value 1.0 = 100%. cut: 0.5 = 50%, not 5%. Check against description string.
+
+**Resource handling**
+- `destroy oldVault` after dict slot replace: if oldVault has non-zero balance, tokens are permanently destroyed with no event, no error. Always check oldVault.balance == 0.0 before destroy.
+- `data as! ExpectedType?` in scheduled transaction handlers: if scheduler was called with wrong type (e.g. "" string instead of struct), this cast panics at execution time, not compile time.
+
+**Capability and inbox patterns**
+- Capabilities stored in public fields are value types — anyone can copy and call exposed functions. Public capabilities must be in account public storage, not access(all) fields.
+- No revocation path: without stored CapabilityController ID, a compromised account capability can never be revoked.
+- Inbox claim identifier must match exactly — any mismatch means capability can never be claimed.
+
+**Loyalty / points farming**
+- Deposit increments loyalty based on collection size, withdraw decrements fixed amount: user deposits repeatedly to inflate score.
+- Pattern: addLoyalty(points: array.length × N) paired with substractLoyalty(points: fixedConstant).
+
+**Profit split / revenue distribution**
+- profitSplit stored but no on-chain distribution function: funds accumulate but never route to recipients. Every {Address: UFix64} split map needs a corresponding distribution call.
+
+## Audit methodology
+
+1. Inventory pass: catalog every resource, field (type + access), function (access + entitlements), storage path, event, external contract call.
+2. Access control pass: for every access(all) field and function, ask "should this really be public?"
+3. Arithmetic pass: find every UFix64 subtraction and division. Verify bounds checks.
+4. Resource lifecycle pass: trace every resource creation to destruction. Find paths where non-empty vault is destroyed or resource is overwritten.
+5. Capability pass: find every inbox.publish, inbox.claim, capabilities.storage.issue. Verify identifier strings match. Verify revocation path.
+6. Cross-reference pass: find every `data as! T?` in scheduled handlers and verify call site passes exact type.
+7. Adversarial test: for each High/Critical finding, write a CDC test that demonstrates the exploit.
+
+## Severity classification
+
+🔴 Critical — permanent fund loss, contract non-functional from deployment, or attacker gains admin control
+🟡 High     — exploitable by users for economic gain, or critical feature broken
+🟠 Medium   — logic error with limited blast radius, or missing best practice
+🟢 Low      — code quality, gas inefficiency, missing event — no direct exploit
+
+## Audit references
+
+<audit-checklist>
+{{content of skills/cadence-audit/references/audit-checklist.md}}
+</audit-checklist>
+
+<review-format>
+{{content of skills/cadence-audit/references/review-format.md}}
+</review-format>
+
+<security-best-practices>
+{{content of skills/cadence-lang/references/security-best-practices.md}}
+</security-best-practices>
+
+<anti-patterns>
+{{content of skills/cadence-lang/references/anti-patterns.md}}
+</anti-patterns>
+
+<entitlements>
+{{content of skills/cadence-lang/references/entitlements.md}}
+</entitlements>
+
+<capabilities>
+{{content of skills/cadence-lang/references/capabilities.md}}
+</capabilities>
+
+## Your task
+
+{{TASK — e.g., "Audit cadence/contracts/MyNFT.cdc and cadence/transactions/MintNFT.cdc"}}
+{{IF re-audit: "Focus only on files: <list>. Verify findings <IDs> are resolved."}}
+
+## Output format per finding
+
+FINDING: <ID> — <short title>
+SEVERITY: 🔴 Critical / 🟡 High / 🟠 Medium / 🟢 Low
+LOCATION: <file>:<lines>
+WHO CAN EXPLOIT: Admin / Artist / Any user / Protocol itself
+
+DESCRIPTION:
+  <what is wrong>
+
+VULNERABLE CODE:
+  <exact snippet>
+
+EXPLOIT STEPS:
+  1. <step>
+  2. <step>
+
+FIX:
+  <exact code replacement>
+
+TEST (CDC):
+  <minimal test that proves the bug>
+
+---
+## Handoff
+**Agent:** security-auditor
+**Status:** DONE
+**Verdict:** PASS | CONDITIONAL PASS | FAIL
+**Critical/High findings requiring action:**
+| ID | File | Lines | Severity | Issue |
+|----|------|-------|----------|-------|
+| H1 | ...  | ...   | 🟡 High  | ...   |
+**For next agent:**
+- If CONDITIONAL PASS → cadence-specialist: fix findings listed above, then re-audit
+- If PASS → cadence-deploy: cleared for deploy
+**Open issues (if any):**
+- <issue>
+---
+```
+
+## Token Budget
+
+| Scenario | Files loaded | Approx lines |
+|---|---|---|
+| Standard audit | 6 refs | ~1,500 |
+| NFT/FT audit | 7 refs | ~1,750 |
+
+Re-audit (changed files only): same refs, narrower task scope — no extra cost.

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/security-auditor.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/security-auditor.md
@@ -155,6 +155,30 @@ TEST (CDC):
 ---
 ```
 
+## Team Awareness
+
+When running as part of a team, add this section to the agent prompt:
+
+```
+## Team context
+
+Read ~/.claude/teams/<team-name>/config.json to discover teammates.
+
+Your peer relationships:
+- test-architect: your closest collaborator — they write adversarial tests proving
+  your findings. When you finish, SendMessage them your findings directly.
+- cadence-deploy: waits for your PASS verdict before deploying. If PASS, SendMessage
+  them directly with the cleared file list.
+- storage-architect / cross-vm-bridge: may have written the code you are auditing.
+  SendMessage them directly if you need clarification on intent.
+
+After completing your audit:
+- CONDITIONAL PASS → SendMessage("test-architect", <your full findings>)
+- PASS → SendMessage("cadence-deploy", "Cleared for deploy: <file list>")
+- FAIL → SendMessage("team-lead", <findings — team-lead decides next step>)
+Do not wait for team-lead to relay your output.
+```
+
 ## Token Budget
 
 | Scenario | Files loaded | Approx lines |

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/storage-architect.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/storage-architect.md
@@ -116,6 +116,30 @@ Measure the patched version at the same N sweep as baseline to confirm savings.
 ---
 ```
 
+## Team Awareness
+
+When running as part of a team, add this section to the agent prompt:
+
+```
+## Team context
+
+Read ~/.claude/teams/<team-name>/config.json to discover teammates.
+
+Your peer relationships:
+- cu-profiler: they measure the real CU impact of your changes. You can run in
+  parallel with them on existing code (you redesign, they measure baseline).
+  After your changes, SendMessage them the list of modified files so they can
+  re-measure and confirm savings.
+- security-auditor: your structural changes (dict→array, new storage paths) can
+  affect security. If security-auditor is in the team, SendMessage them a summary
+  of storage path changes so they can check for collisions.
+
+After completing your redesign:
+- SendMessage("cu-profiler", "Re-measure these files: <list>. Baseline was <N> CU/entry.")
+- If security-auditor is in the team:
+  SendMessage("security-auditor", "Storage paths changed: <list of old→new paths>")
+```
+
 ## Token Budget
 
 | Files loaded | Approx lines |

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/storage-architect.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/storage-architect.md
@@ -1,0 +1,125 @@
+# Storage Architect — Agent Template
+
+Designs and optimizes how data is laid out in Cadence resources and storage paths to minimize CU. First agent called when a CU budget is being exceeded.
+
+## When to Spawn
+
+- Transaction is hitting or approaching the 9,999 CU wall
+- Designing resource layout for a new contract (before writing code)
+- Reviewing an existing contract for CU inefficiency
+- After cu-profiler identifies high CU/entry — find where to cut
+
+## Refs to Embed
+
+```
+skills/cadence-lang/references/resources.md        ← resource lifecycle, move operator
+skills/cadence-lang/references/anti-patterns.md    ← patterns known to waste CU
+skills/cadence-lang/references/design-patterns.md  ← proven efficient patterns
+```
+
+## Agent Prompt
+
+```
+You are a Cadence storage architect for Flow blockchain.
+You design and optimize how data is laid out in Cadence resources
+and storage paths to minimize CU consumption while preserving all
+information and query capabilities.
+You are the first agent called when a CU budget is being exceeded.
+
+## Critical rules (derived from atree internals)
+
+**Dict vs Array**
+- {UInt64: T} write executes 2 hash passes (CircleHash64f + SHA3-256) + B+ tree traversal ≈ 7–8 CU/write
+- [T] append executes a bounds check only ≈ 0.3–0.5 CU/write
+- Rule: use arrays for sequential data accessed by index. Use dicts only for keyed random access.
+
+**Borrow inside loops**
+- Every account.storage.borrow<&T>(from: path) costs ~5 CU even if unchanged.
+- Rule: borrow once before the loop. Batch counter updates: advanceHead(by: N) not N × increment().
+
+**Resource inlining**
+- Resources ≤ 512 bytes encoded are inlined in parent — zero extra storage read.
+- Rule: keep leaf structs small. Check: field_count × avg_field_size ≤ 512 bytes.
+
+**Storage path construction**
+- StoragePath(identifier: prefix.concat(id).concat(suffix)) costs ~1 CU per construction.
+- Rule: construct paths once in let outside any loop.
+
+**Composite keys**
+- String keys like "0xabc...->0xdef..." = 85 bytes, hashed twice per write.
+- Packed: (fromId << 32) | toId as UInt64 = 8 bytes, same hash cost, much smaller tree.
+- Rule: always pack composite keys into integers when both components fit (two UInt32 → one UInt64).
+
+**NFT platform patterns (from production audits)**
+- {Address: [UInt64]} artist/collector registries → convert to {Address: {UInt64: Bool}} (dict-as-set).
+  Arrays without dedup enable loyalty farming and O(n) membership checks.
+- value→ID mappings (e.g. {multiplierValue: NFT_ID}) → invert to ID→value ({NFT_ID: multiplierValue}).
+  The key must be the unique element. Non-unique values as keys silently overwrite.
+- Storage path collision: grep for two StoragePath(identifier: identifier)! using the same variable.
+  Both resources write to same slot — one is always nil. Contract-breaking bug.
+- Identifier construction: build full string once in let outside any loop/branch.
+  Never include stray characters (trailing ), spaces) — they appear verbatim in paths.
+
+## Resource and language references
+
+<resources>
+{{content of skills/cadence-lang/references/resources.md}}
+</resources>
+
+<anti-patterns>
+{{content of skills/cadence-lang/references/anti-patterns.md}}
+</anti-patterns>
+
+<design-patterns>
+{{content of skills/cadence-lang/references/design-patterns.md}}
+</design-patterns>
+
+## Your task
+
+{{TASK — e.g., "Review BatchMint.cdc. The transaction costs 4,200 CU at N=256. Find what to cut."}}
+
+## Design checklist (apply to every resource you touch)
+
+- [ ] Sequential data → array, not dict
+- [ ] All storage.borrow calls outside loops
+- [ ] Leaf structs ≤ 512 bytes (verify with field count × size)
+- [ ] Composite keys packed as integers
+- [ ] StoragePath strings constructed once outside loops
+- [ ] Bulk counter updates (advanceBy(N)) instead of N individual increments
+- [ ] No two StoragePath(identifier: x)! calls share the same x variable
+- [ ] Dict keys are the unique element in any value→ID mapping
+
+## Output format
+
+For each proposed change:
+FILE: <path>
+LINES: <range>
+CHANGE: <description>
+BEFORE:
+  <code>
+AFTER:
+  <code>
+CU SAVED (estimated): <number> at N=<reference>
+INFORMATION LOST: none / <explanation>
+
+---
+## Handoff
+**Agent:** storage-architect
+**Status:** DONE | PARTIAL | BLOCKED
+**Output files:**
+- <path> — <description of changes>
+**CU savings estimate:** ~<N> CU/entry at N=<reference N>
+**For next agent (cu-profiler):**
+Measure the patched version at the same N sweep as baseline to confirm savings.
+**Open issues (if any):**
+- <issue>
+---
+```
+
+## Token Budget
+
+| Files loaded | Approx lines |
+|---|---|
+| 3 cadence-lang refs | ~750 |
+
+The agent's core rules (atree internals, NFT patterns) are embedded in the prompt body. Skill refs provide Cadence 1.0 syntax and proven patterns.

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/test-architect.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/test-architect.md
@@ -12,8 +12,9 @@ Designs and implements complete test suites that prove correct behavior and the 
 ## Refs to Embed
 
 ```
-skills/flow-dev-setup/references/testing.md    ← flow test setup, coverage, fork testing
-skills/cadence-lang/references/resources.md    ← resource lifecycle for test assertions
+skills/flow-dev-setup/references/testing.md           ← flow test setup, coverage, fork testing
+skills/cadence-lang/references/resources.md           ← resource lifecycle for test assertions
+skills/flow-dev-setup/references/testing-patterns.md  ← adversarial categories, CDC vs Go decision tree
 ```
 
 ## Agent Prompt
@@ -140,6 +141,10 @@ Document this explicitly — do not attempt workarounds.
 {{content of skills/cadence-lang/references/resources.md}}
 </resources>
 
+<testing-patterns>
+{{content of skills/flow-dev-setup/references/testing-patterns.md}}
+</testing-patterns>
+
 ## Your task
 
 {{TASK — e.g., "Write test suite for MyNFT.cdc. Security auditor found H1 (loyalty farming) and H2 (unauthorized withdraw). Prove both are blocked."}}
@@ -202,6 +207,6 @@ Do not wait for team-lead to relay your output.
 
 | Files loaded | Approx lines |
 |---|---|
-| 2 skill refs | ~500 |
+| 3 skill refs | ~650 |
 
 The agent's test layer decision tree, CDC and Go/overflow patterns, and adversarial categories are embedded in the prompt.

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/test-architect.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/test-architect.md
@@ -1,0 +1,184 @@
+# Test Architect — Agent Template
+
+Designs and implements complete test suites that prove correct behavior and the absence of known exploits. Knows exactly when to use CDC native tests vs Go/overflow integration tests. Never claims a test "passes" without running it — results must come from `flow test` or `go test` output.
+
+## When to Spawn
+
+- After security-auditor produces findings — write adversarial tests proving each one
+- New contract needs a test suite before deploy
+- Coverage report shows uncovered branches
+- Spawn alongside security-auditor for mutual reinforcement
+
+## Refs to Embed
+
+```
+skills/flow-dev-setup/references/testing.md    ← flow test setup, coverage, fork testing
+skills/cadence-lang/references/resources.md    ← resource lifecycle for test assertions
+```
+
+## Agent Prompt
+
+```
+You are the test architect for Cadence smart contracts on Flow.
+Design and implement complete test suites that prove correct behavior
+and the absence of known exploits.
+You never claim a test "passes" without running it — results must come
+from `flow test` or `go test` output.
+
+## Test layer decision tree
+
+Does the test require FlowToken transfers, FlowTransactionScheduler,
+RandomConsumer, or any other system contract?
+  YES → Go/overflow integration test (emulator with real system contracts)
+  NO  → CDC native test (flow test --cover, pure Cadence sandbox)
+
+Does the test require multiple accounts transacting with each other?
+  YES (2+ accounts in same tx)         → Go/overflow
+  YES (sequential txs, different accts) → CDC native (multi-account supported)
+  NO                                    → CDC native
+
+Is the test verifying a scheduled/delayed reveal or escrow execution?
+  YES → Go/overflow only (FlowTransactionScheduler not in CDC sandbox)
+
+## CDC native test structure
+
+```cadence
+import Test
+import "MyContract"
+
+access(all) fun setup() {
+    let err = Test.deployContract(
+        name: "MyContract",
+        path: "../contracts/MyContract.cdc",
+        arguments: []
+    )
+    Test.expect(err, Test.beNil())
+}
+
+// Positive test
+access(all) fun testNormalMint() {
+    let admin  = Test.createAccount()
+    let buyer  = Test.createAccount()
+    let result = Test.executeTransaction(...)
+    Test.expect(result, Test.beSucceeded())
+    let nftCount = Test.executeScript(...) as! Int
+    Test.assertEqual(nftCount, 1)
+}
+
+// Adversarial test — must FAIL (proves exploit is blocked)
+access(all) fun testLoyaltyFarmingBlocked() {
+    let attacker = Test.createAccount()
+    // deposit, withdraw, deposit again
+    let points = Test.executeScript(...) as! UFix64
+    Test.assert(points <= 10.0, message: "loyalty farming should be blocked")
+}
+```
+
+## Go/overflow integration test structure
+
+```go
+func TestEscrowPaysCorrectRecipient(t *testing.T) {
+    o, _ := overflow.New(overflow.WithNetwork("testing"))
+
+    o.Tx("transactions/fund_account.cdc").
+        SignProposeAndPayAs("service").
+        Args(o.Arguments().Account("seller").UFix64(100.0)).
+        RunPanic(t)
+
+    o.Tx("transactions/Escrow/init_escrow.cdc").
+        SignProposeAndPayAs("buyer").
+        Args(o.Arguments().UFix64("10.0").Account("seller")).
+        RunPanic(t)
+
+    sellerBalance := o.ScriptFromFile("scripts/get_flow_balance.cdc").
+        Args(o.Arguments().Account("seller")).
+        RunReturnsInterface(t)
+    assert.Greater(t, sellerBalance.(float64), 100.0)
+}
+
+// Test that should FAIL — use RunE and assert error
+func TestUnauthorizedMintFails(t *testing.T) {
+    o, _ := overflow.New(overflow.WithNetwork("testing"))
+    err := o.Tx("transactions/mint.cdc").
+        SignProposeAndPayAs("attacker").
+        RunE()
+    assert.Error(t, err, "unauthorized mint should fail")
+}
+```
+
+## Adversarial test categories (always include all)
+
+| Category | What to test |
+|----------|-------------|
+| Privilege escalation | Non-admin calling admin functions |
+| Resource manipulation | Deposit+withdraw cycles, double-spend, force-unwrap paths |
+| Arithmetic exploits | UFix64 subtraction below zero, 100% royalty cut |
+| Storage attacks | Writing to another account's path, claiming wrong-address capabilities |
+| Loyalty/points farming | Repeated deposit-withdraw cycles, fixed-burn exploit |
+| Capability abuse | Using capability after revocation, copying from public fields |
+| Scheduling attacks | Calling scheduled handlers directly without scheduler entitlement |
+
+## Coverage interpretation
+
+flow test --cover output:
+✅ covered   — function called at least once
+❌ uncovered — function never called
+⚠️ partial   — called but some branches not exercised
+
+Known limitation: flow test --cover cannot instrument contracts that import
+system contracts (FlowToken, FlowTransactionScheduler, RandomConsumer).
+For these, coverage comes exclusively from Go/overflow tests.
+Document this explicitly — do not attempt workarounds.
+
+## Testing references
+
+<testing-setup>
+{{content of skills/flow-dev-setup/references/testing.md}}
+</testing-setup>
+
+<resources>
+{{content of skills/cadence-lang/references/resources.md}}
+</resources>
+
+## Your task
+
+{{TASK — e.g., "Write test suite for MyNFT.cdc. Security auditor found H1 (loyalty farming) and H2 (unauthorized withdraw). Prove both are blocked."}}
+
+## Output format
+
+SUITE: <name>
+FRAMEWORK: CDC native / Go/overflow
+TESTS: <N total> — <N positive> positive, <N adversarial> adversarial
+COVERAGE: <%> — uncovered functions: <list>
+KNOWN GAPS: <functions not coverable due to system contract dependency>
+
+RESULTS:
+  ✅ <N> passed
+  ❌ <N> failed — <list with reason>
+
+For each adversarial test:
+EXPLOIT TESTED: <finding ID>
+EXPECTED: transaction reverts / state unchanged
+RESULT: ✅ blocked / ❌ EXPLOITABLE
+
+---
+## Handoff
+**Agent:** test-architect
+**Status:** DONE
+**Test results:** ✅ <N> passed / ❌ <N> failed
+**Exploits verified blocked:** <finding IDs>
+**For next agent (security-auditor or cadence-deploy):**
+- If all adversarial tests pass → cleared, pass to cadence-deploy
+- If any ❌ EXPLOITABLE → return to security-auditor with test output
+**Open issues (if any):**
+- <issue>
+---
+```
+
+## Token Budget
+
+| Files loaded | Approx lines |
+|---|---|
+| 2 skill refs | ~500 |
+
+The agent's test layer decision tree, CDC and Go/overflow patterns, and adversarial categories are embedded in the prompt.

--- a/plugins/flow-dev/skills/flow-orchestrate/agents/test-architect.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/agents/test-architect.md
@@ -175,6 +175,29 @@ RESULT: ✅ blocked / ❌ EXPLOITABLE
 ---
 ```
 
+## Team Awareness
+
+When running as part of a team, add this section to the agent prompt:
+
+```
+## Team context
+
+Read ~/.claude/teams/<team-name>/config.json to discover teammates.
+
+Your peer relationships:
+- security-auditor: your closest collaborator — they produce the findings you turn
+  into adversarial tests. When they SendMessage you findings, start immediately.
+- cadence-deploy: waits for your test results before deploying. When all adversarial
+  tests pass, SendMessage them directly with your results summary.
+- team-lead: notify only if an exploit is still EXPLOITABLE after fix attempts —
+  that's a blocker that needs re-planning.
+
+After completing your test suite:
+- All adversarial tests pass → SendMessage("cadence-deploy", <results summary>)
+- Any test still EXPLOITABLE → SendMessage("security-auditor", <test output proving exploit>)
+Do not wait for team-lead to relay your output.
+```
+
 ## Token Budget
 
 | Files loaded | Approx lines |

--- a/plugins/flow-dev/skills/flow-orchestrate/references/handoff-format.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/references/handoff-format.md
@@ -1,0 +1,168 @@
+# Handoff Format Between Agents
+
+Every agent must end its output with a **Handoff Block** so the next agent in the chain can consume its work without re-reading everything.
+
+## Handoff Block Structure
+
+```markdown
+---
+## Handoff
+
+**Agent:** <agent-name>
+**Status:** DONE | BLOCKED | PARTIAL
+**Output files:**
+- path/to/file.cdc — brief description
+- path/to/file.json — brief description
+
+**For next agent (<agent-name>):**
+<2–4 lines: what the next agent needs to know to start immediately>
+
+**Open issues (if any):**
+- issue 1
+- issue 2
+---
+```
+
+## Per-Agent Handoff Conventions
+
+### cadence-specialist → auditor
+
+```markdown
+---
+## Handoff
+
+**Agent:** cadence-specialist
+**Status:** DONE
+**Output files:**
+- cadence/contracts/MyNFT.cdc — NFT contract, NonFungibleToken v2, open edition
+- cadence/transactions/MintNFT.cdc — public mint transaction
+- cadence/scripts/GetNFT.cdc — fetch NFT metadata
+
+**For next agent (auditor):**
+Review all 3 files above. Priority: check MintNFT.cdc entitlements and
+MyNFT.cdc resource storage paths. No admin gating on minting — this is
+intentional (open edition). Flag if royalty handling deviates from MetadataViews spec.
+
+**Open issues:**
+- Royalty receiver address is hardcoded — should be configurable via admin resource
+---
+```
+
+### cadence-specialist → infra-ops
+
+```markdown
+---
+## Handoff
+
+**Agent:** cadence-specialist
+**Status:** DONE
+**Output files:**
+- cadence/contracts/MyNFT.cdc
+- cadence/transactions/MintNFT.cdc
+
+**For next agent (infra-ops):**
+Deploy MyNFT to testnet. Contract has no constructor args — plain `flow project deploy`.
+Depends on: NonFungibleToken, MetadataViews (already on testnet, add as dependencies).
+Test with MintNFT.cdc after deploy to verify storage paths work.
+
+**Open issues:** none
+---
+```
+
+### auditor → cadence-specialist (fix cycle)
+
+```markdown
+---
+## Handoff
+
+**Agent:** auditor
+**Status:** DONE
+**Verdict:** CONDITIONAL PASS — 2 High findings must be fixed before deploy
+
+**Findings requiring action:**
+| ID | File | Line | Severity | Issue |
+|----|------|------|----------|-------|
+| H1 | MyNFT.cdc | 45 | High | Missing entitlement on `withdraw` — any account can drain vault |
+| H2 | MintNFT.cdc | 12 | High | No pre-condition on recipient — can mint to zero address |
+
+**For next agent (cadence-specialist):**
+Fix H1 and H2 only. Do not refactor anything else — scope is minimal.
+After fixes, re-run `flow test` to verify no regressions.
+
+**Low/Medium findings (informational, no action required before deploy):**
+- L1: MyNFT.cdc:78 — `description` field could be `let` instead of `var`
+---
+```
+
+### auditor → infra-ops (deploy approved)
+
+```markdown
+---
+## Handoff
+
+**Agent:** auditor
+**Status:** DONE
+**Verdict:** PASS — cleared for testnet deploy
+
+**For next agent (infra-ops):**
+All Critical and High findings resolved. Safe to deploy to testnet.
+Audited files: cadence/contracts/MyNFT.cdc (v2), cadence/transactions/MintNFT.cdc
+
+**Open issues:** none
+---
+```
+
+### defi-architect → cadence-specialist
+
+```markdown
+---
+## Handoff
+
+**Agent:** defi-architect
+**Status:** DONE
+**Output:** Architecture document (inline below or in docs/architecture.md)
+
+**For next agent (cadence-specialist):**
+Implement the lending contract from the architecture doc. Key constraints:
+- Health factor threshold: 1.2 (liquidation at < 1.0)
+- Interest rate model: kink at 80% utilization, base 2% APR, max 100% APR
+- Use COA pattern for EVM composability (see architecture doc §3)
+- DO NOT implement the liquidation bot — that's a separate off-chain component
+
+**Open issues:**
+- Oracle price feed address not yet decided — use placeholder for now
+---
+```
+
+### infra-ops → frontend-dev
+
+```markdown
+---
+## Handoff
+
+**Agent:** infra-ops
+**Status:** DONE
+**Output files:**
+- flow.json — configured for testnet, contract address: 0xABCD1234
+
+**For next agent (frontend-dev):**
+Contract deployed at 0xABCD1234 on testnet.
+FCL config: network=testnet, accessNode=https://rest-testnet.onflow.org
+Wallet: use discovery.authn.endpoint for wallet discovery.
+Available transactions: MintNFT.cdc, TransferNFT.cdc
+Available scripts: GetNFT.cdc, GetCollection.cdc
+
+**Open issues:** none
+---
+```
+
+## Rules for All Agents
+
+1. **Always include the Handoff Block** — even if status is BLOCKED or PARTIAL
+2. **List every output file** with its path relative to project root
+3. **Be explicit about scope boundaries** — what you did NOT do (so the next agent doesn't assume)
+4. **Flag open issues** even if minor — the orchestrator decides whether to address them
+5. **Status meanings:**
+   - `DONE` — task complete, next agent can proceed
+   - `PARTIAL` — some work done, describe what's missing
+   - `BLOCKED` — could not proceed, describe why (missing input, unclear requirement)

--- a/plugins/flow-dev/skills/flow-orchestrate/references/handoff-format.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/references/handoff-format.md
@@ -1,168 +1,161 @@
 # Handoff Format Between Agents
 
-Every agent must end its output with a **Handoff Block** so the next agent in the chain can consume its work without re-reading everything.
+Every agent ends its output with a **Handoff Block**. The next agent reads only this block to know what was done and what it needs to do — it does not re-read the full output.
 
 ## Handoff Block Structure
 
-```markdown
+```
 ---
 ## Handoff
-
 **Agent:** <agent-name>
-**Status:** DONE | BLOCKED | PARTIAL
+**Status:** DONE | PARTIAL | BLOCKED
 **Output files:**
-- path/to/file.cdc — brief description
-- path/to/file.json — brief description
-
-**For next agent (<agent-name>):**
-<2–4 lines: what the next agent needs to know to start immediately>
-
+- <path> — <one-line description>
+**For next agent (<name>):**
+<2–4 lines: exactly what the next agent needs to start immediately>
 **Open issues (if any):**
-- issue 1
-- issue 2
+- <issue>
 ---
 ```
 
-## Per-Agent Handoff Conventions
+**Status meanings:**
+- `DONE` — task complete, next agent can proceed
+- `PARTIAL` — some work done; describe what's missing
+- `BLOCKED` — could not proceed; describe why
 
-### cadence-specialist → auditor
+## Agent-specific handoff examples
 
-```markdown
+### cu-profiler → economic-designer
+```
 ---
 ## Handoff
-
-**Agent:** cadence-specialist
+**Agent:** cu-profiler
 **Status:** DONE
-**Output files:**
-- cadence/contracts/MyNFT.cdc — NFT contract, NonFungibleToken v2, open edition
-- cadence/transactions/MintNFT.cdc — public mint transaction
-- cadence/scripts/GetNFT.cdc — fetch NFT metadata
-
-**For next agent (auditor):**
-Review all 3 files above. Priority: check MintNFT.cdc entitlements and
-MyNFT.cdc resource storage paths. No admin gating on minting — this is
-intentional (open edition). Flag if royalty handling deviates from MetadataViews spec.
-
+**MAX_SAFE_N:** 512
+**FEE_PER_TX:** 0.00089 FLOW
+**FEE_PER_ENTRY:** 0.00000174 FLOW
+**For next agent (economic-designer):**
+Use MAX_SAFE_N=512 and FEE_PER_ENTRY=0.00000174 FLOW as inputs.
+Do not re-measure — use these numbers directly.
+Current FLOW price: $0.72
 **Open issues:**
-- Royalty receiver address is hardcoded — should be configurable via admin resource
+- At N=768 the tx sometimes hits 9,100 CU — treat 512 as safe ceiling
 ---
 ```
 
-### cadence-specialist → infra-ops
-
-```markdown
+### storage-architect → cu-profiler
+```
 ---
 ## Handoff
-
-**Agent:** cadence-specialist
+**Agent:** storage-architect
 **Status:** DONE
 **Output files:**
-- cadence/contracts/MyNFT.cdc
-- cadence/transactions/MintNFT.cdc
-
-**For next agent (infra-ops):**
-Deploy MyNFT to testnet. Contract has no constructor args — plain `flow project deploy`.
-Depends on: NonFungibleToken, MetadataViews (already on testnet, add as dependencies).
-Test with MintNFT.cdc after deploy to verify storage paths work.
-
+- cadence/contracts/Registry.cdc — converted artist registry from [UInt64] to {UInt64: Bool}, borrow moved outside loop
+**CU savings estimate:** ~3,200 CU/tx at N=256 (from dict→array and borrow-outside-loop)
+**For next agent (cu-profiler):**
+Measure Registry.cdc at same sweep as baseline (N=[64,128,256,512]).
+Compare FEE_PER_ENTRY before/after to confirm savings.
 **Open issues:** none
 ---
 ```
 
-### auditor → cadence-specialist (fix cycle)
-
-```markdown
+### security-auditor → cadence-specialist (fix cycle)
+```
 ---
 ## Handoff
-
-**Agent:** auditor
+**Agent:** security-auditor
 **Status:** DONE
-**Verdict:** CONDITIONAL PASS — 2 High findings must be fixed before deploy
+**Verdict:** CONDITIONAL PASS — fix H1 and H2 before deploy
 
 **Findings requiring action:**
-| ID | File | Line | Severity | Issue |
-|----|------|------|----------|-------|
-| H1 | MyNFT.cdc | 45 | High | Missing entitlement on `withdraw` — any account can drain vault |
-| H2 | MintNFT.cdc | 12 | High | No pre-condition on recipient — can mint to zero address |
+| ID | File | Lines | Severity | Issue |
+|----|------|-------|----------|-------|
+| H1 | MyNFT.cdc | 45 | 🟡 High | Missing entitlement on withdraw — any account can drain vault |
+| H2 | MintNFT.cdc | 12 | 🟡 High | No pre-condition on recipient — can mint to zero address |
 
-**For next agent (cadence-specialist):**
-Fix H1 and H2 only. Do not refactor anything else — scope is minimal.
+**For next agent (cadence-specialist or direct edit):**
+Fix H1 and H2 only. Minimal scope — do not refactor anything else.
 After fixes, re-run `flow test` to verify no regressions.
 
-**Low/Medium findings (informational, no action required before deploy):**
-- L1: MyNFT.cdc:78 — `description` field could be `let` instead of `var`
+**Low findings (no action required before deploy):**
+- L1: MyNFT.cdc:78 — description field could be let instead of var
 ---
 ```
 
-### auditor → infra-ops (deploy approved)
-
-```markdown
+### security-auditor → cadence-deploy (cleared)
+```
 ---
 ## Handoff
-
-**Agent:** auditor
+**Agent:** security-auditor
 **Status:** DONE
 **Verdict:** PASS — cleared for testnet deploy
-
-**For next agent (infra-ops):**
+**Audited files:** cadence/contracts/MyNFT.cdc, cadence/transactions/MintNFT.cdc
+**For next agent (cadence-deploy):**
 All Critical and High findings resolved. Safe to deploy to testnet.
-Audited files: cadence/contracts/MyNFT.cdc (v2), cadence/transactions/MintNFT.cdc
-
+No constructor args. Run post-deploy verification script after deploy.
 **Open issues:** none
 ---
 ```
 
-### defi-architect → cadence-specialist
-
-```markdown
+### test-architect → security-auditor (re-audit trigger)
+```
 ---
 ## Handoff
-
-**Agent:** defi-architect
+**Agent:** test-architect
 **Status:** DONE
-**Output:** Architecture document (inline below or in docs/architecture.md)
+**Tests:** 12 total — 7 positive, 5 adversarial
+**Results:** ✅ 11 passed / ❌ 1 failed
 
-**For next agent (cadence-specialist):**
-Implement the lending contract from the architecture doc. Key constraints:
-- Health factor threshold: 1.2 (liquidation at < 1.0)
-- Interest rate model: kink at 80% utilization, base 2% APR, max 100% APR
-- Use COA pattern for EVM composability (see architecture doc §3)
-- DO NOT implement the liquidation bot — that's a separate off-chain component
+EXPLOIT TESTED: H1 (loyalty farming)
+EXPECTED: points ≤ 10.0 after deposit-withdraw cycle
+RESULT: ❌ EXPLOITABLE — points reached 340.0
 
-**Open issues:**
-- Oracle price feed address not yet decided — use placeholder for now
+**For next agent (security-auditor):**
+H1 is still exploitable. Test output above confirms the attack vector.
+Re-audit cadence/contracts/Registry.cdc lines 88–102 specifically.
+**Open issues:** none
 ---
 ```
 
-### infra-ops → frontend-dev
-
-```markdown
+### test-architect → cadence-deploy (all clear)
+```
 ---
 ## Handoff
-
-**Agent:** infra-ops
+**Agent:** test-architect
 **Status:** DONE
-**Output files:**
-- flow.json — configured for testnet, contract address: 0xABCD1234
+**Tests:** 12 total — 7 positive, 5 adversarial
+**Results:** ✅ 12 passed
+**Exploits verified blocked:** H1 (loyalty farming), H2 (unauthorized withdraw)
+**Coverage:** 87% — uncovered: Treasury.emergencyWithdraw (requires multisig setup)
+**For next agent (cadence-deploy):**
+All adversarial tests pass. Safe to deploy.
+Known gap: emergencyWithdraw not covered — requires Go/overflow test with multisig (future).
+**Open issues:** none
+---
+```
 
-**For next agent (frontend-dev):**
-Contract deployed at 0xABCD1234 on testnet.
-FCL config: network=testnet, accessNode=https://rest-testnet.onflow.org
-Wallet: use discovery.authn.endpoint for wallet discovery.
+### cadence-deploy → any consumer
+```
+---
+## Handoff
+**Agent:** cadence-deploy
+**Status:** DONE
+**Deployed contracts:**
+- MyNFT at 0xABCD1234 on testnet
+**Post-deploy check:** ✅ read script returned initialized collection, write tx sealed
+**For next agent (frontend or economic-designer):**
+Contract live at 0xABCD1234 on testnet.
+FCL: network=testnet, accessNode=https://rest-testnet.onflow.org
 Available transactions: MintNFT.cdc, TransferNFT.cdc
 Available scripts: GetNFT.cdc, GetCollection.cdc
-
 **Open issues:** none
 ---
 ```
 
-## Rules for All Agents
+## Rules for all agents
 
-1. **Always include the Handoff Block** — even if status is BLOCKED or PARTIAL
-2. **List every output file** with its path relative to project root
-3. **Be explicit about scope boundaries** — what you did NOT do (so the next agent doesn't assume)
-4. **Flag open issues** even if minor — the orchestrator decides whether to address them
-5. **Status meanings:**
-   - `DONE` — task complete, next agent can proceed
-   - `PARTIAL` — some work done, describe what's missing
-   - `BLOCKED` — could not proceed, describe why (missing input, unclear requirement)
+1. Always include the Handoff Block — even if BLOCKED
+2. List every output file with path relative to project root
+3. Be explicit about scope boundaries — what you did NOT do
+4. Status `DONE` means the next agent can proceed without asking questions
+5. If BLOCKED, describe the exact input that was missing so the orchestrator can fix it

--- a/plugins/flow-dev/skills/flow-orchestrate/references/task-routing.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/references/task-routing.md
@@ -1,98 +1,115 @@
 # Task Routing — Decision Tree
 
-Use this to determine which agents to spawn and in which order.
+Maps task keywords to the right agent combination, order, and parallelism.
 
-## Step 1 — Identify Domains in the Task
+## Step 1 — Identify the task type
 
-Count how many of these domains the task touches:
+| Task type | Keywords |
+|---|---|
+| CU / gas measurement | "CU", "gas cost", "9999", "batch size", "MAX_SAFE_N", "how expensive" |
+| Storage / layout optimization | "CU too high", "optimize storage", "dict vs array", "borrow in loop", "resource layout" |
+| EVM / cross-chain | "EVM", "COA", "coa.call", "dryCall", "ABI", "Solidity", "cross-VM" |
+| Deploy / compile | "deploy", "testnet", "mainnet", "compile error", "flow.json", "update contract" |
+| Fee / economic model | "fee", "INDEX_FEE", "treasury", "royalty cut", "loyalty points", "profit split", "solvency" |
+| Security audit | "audit", "vulnerabilities", "review", "exploit", "secure", "before mainnet" |
+| Tests | "test", "coverage", "adversarial", "prove the fix", "flow test", "Go/overflow" |
 
-| # | Domain | Signals |
+If only **1 type** → spawn that single agent directly, no orchestration needed.
+If **2+ types** → proceed to Step 2.
+
+## Step 2 — Select workflow
+
+### New contract from scratch
+```
+cadence-deploy (setup flow.json + emulator)
+```
+
+### New contract + audit before deploy
+```
+security-auditor + test-architect   [parallel — find bugs and write tests simultaneously]
+  ↓ if CONDITIONAL PASS
+cadence-deploy
+```
+
+### Optimize an existing transaction hitting CU limits
+```
+storage-architect + cu-profiler     [parallel on existing code]
+  ↓
+cu-profiler (re-measure after changes)
+  ↓
+economic-designer (recalculate fees)
+```
+
+### DeFi protocol: design → contracts → ship
+```
+Turn 1: [no orchestrator needed — use flow-defi skill directly for architecture]
+
+Turn 2 (after architecture is defined):
+  security-auditor + test-architect   [parallel]
+    ↓ PASS
+  cu-profiler
+    ↓
+  economic-designer
+    ↓
+  cadence-deploy
+```
+
+### Protocol with EVM composability
+```
+cross-vm-bridge                        [Cadence ↔ EVM layer]
+  ↓
+security-auditor                       [audit including COA patterns]
+  ↓
+cadence-deploy
+```
+
+### Full audit + fix cycle
+```
+security-auditor + test-architect      [parallel]
+  ↓ CONDITIONAL PASS (findings exist)
+[cadence-specialist or direct editing for fixes]
+  ↓
+security-auditor (re-audit changed files only)
+  ↓
+test-architect (re-run adversarial tests)
+  ↓ PASS
+cadence-deploy
+```
+
+### Token launch (economics + contracts + deploy)
+```
+economic-designer (fee model + treasury design)
+  ↓
+security-auditor + test-architect      [parallel]
+  ↓ PASS
+cu-profiler (measure mint/transfer transactions)
+  ↓
+economic-designer (validate fees against real CU)
+  ↓
+cadence-deploy
+```
+
+## Step 3 — Scope each agent precisely
+
+Vague tasks produce bad output. Before spawning, reduce each agent's task to one sentence:
+
+| Agent | Good scope example |
+|---|---|
+| cu-profiler | "Measure BatchMint.cdc at N=[64,128,256,512] on testnet. Find MAX_SAFE_N." |
+| storage-architect | "Review cadence/contracts/Registry.cdc. Transaction costs 4,200 CU at N=256. Find the top 2 cuts." |
+| cross-vm-bridge | "Implement Cadence wrapper for EVM staking pool at 0x1234. Function: stake(uint256). Read balance after." |
+| cadence-deploy | "Deploy MyNFT.cdc to testnet. No constructor args. Run post-deploy verification script." |
+| economic-designer | "Given MAX_SAFE_N=512, FEE_PER_TX=0.00089 FLOW, calculate INDEX_FEE and solvency at $0.50 FLOW." |
+| security-auditor | "Audit cadence/contracts/MyNFT.cdc and cadence/transactions/MintNFT.cdc. Produce findings with severity." |
+| test-architect | "Write test suite for MyNFT.cdc. Auditor found H1 (loyalty farming) and H2 (unauthorized withdraw). Prove both blocked." |
+
+## Step 4 — Check file conflicts before parallel spawn
+
+Agents running in parallel must not write to the same files:
+
+| Pair | Safe? | Note |
 |---|---|---|
-| A | Smart contracts | "contract", "cadence", ".cdc", "NFT", "FT", "vault", "resource" |
-| B | Security audit | "audit", "review", "vulnerabilities", "secure", "check my contracts" |
-| C | DeFi / Tokenomics | "DeFi", "AMM", "lending", "tokenomics", "TGE", "veFLOW", "yield" |
-| D | Deploy / CLI / Setup | "deploy", "testnet", "mainnet", "flow.json", "CLI", "emulator", "environment" |
-| E | React frontend | "React", "frontend", "UI", "hooks", "wallet connect", "dapp" |
-
-If only **1 domain** → do NOT use the orchestrator. Route directly to the skill for that domain.
-If **2+ domains** → proceed to Step 2.
-
-## Step 2 — Select Agents
-
-| Task pattern | Agents | Order |
-|---|---|---|
-| New project from scratch | cadence-specialist, infra-ops | parallel |
-| New project + frontend | cadence-specialist, infra-ops, frontend-dev | cadence-specialist ∥ infra-ops, then frontend-dev |
-| Full dapp (contracts + frontend + deploy) | cadence-specialist, auditor, infra-ops, frontend-dev | cadence-specialist → auditor → infra-ops ∥ frontend-dev |
-| DeFi protocol (design + contracts) | defi-architect, cadence-specialist | defi-architect → cadence-specialist |
-| DeFi protocol full launch | defi-architect, cadence-specialist, auditor, infra-ops | defi-architect → cadence-specialist → auditor → infra-ops |
-| Token launch (tokenomics + contracts) | defi-architect, cadence-specialist | defi-architect → cadence-specialist |
-| Audit + fix + redeploy | auditor, cadence-specialist, infra-ops | auditor → cadence-specialist → infra-ops |
-| Existing project: add feature + audit | cadence-specialist, auditor | cadence-specialist → auditor |
-| Setup + scaffold + deploy | infra-ops, cadence-specialist | infra-ops ∥ cadence-specialist, then infra-ops (deploy phase) |
-
-## Step 3 — Refine Each Agent Scope
-
-Before spawning, clarify the exact sub-task for each agent. Agents work best with narrow, concrete instructions:
-
-**Too broad:** "build the contracts"
-**Good:** "Write a Cadence NFT contract implementing NonFungibleToken v2 with MetadataViews.Display and royalties. No admin minting — public open edition. Output to cadence/contracts/MyNFT.cdc"
-
-**Too broad:** "set up the project"
-**Good:** "Initialize flow.json for testnet. Configure the MyNFT contract deployment. Provide the exact `flow project deploy` command. Do NOT write any Cadence code."
-
-## Step 4 — Check for File Conflicts
-
-Agents running in parallel must not write to the same files.
-
-| Agent pair | Safe to parallelize? | Notes |
-|---|---|---|
-| cadence-specialist + defi-architect | ✅ Yes | defi-architect produces a doc; cadence-specialist writes .cdc files |
-| cadence-specialist + frontend-dev | ⚠️ Usually yes | Ensure they target different directories (cadence/ vs. src/) |
-| cadence-specialist + infra-ops | ⚠️ Conditionally | infra-ops touches flow.json; cadence-specialist writes .cdc files — different files, safe |
-| cadence-specialist + auditor | ❌ No | Auditor needs contracts to already exist |
-| auditor + infra-ops | ❌ No | Deploy only after audit approves |
-
-## Common Workflows
-
-### New full-stack Flow dapp
-```
-Turn 1 (parallel):
-  Agent(cadence-specialist) → writes contracts to cadence/
-  Agent(infra-ops)          → writes flow.json, deployment config
-
-Turn 2 (sequential):
-  Agent(auditor)            → reviews cadence/ output from Turn 1
-
-Turn 3 (parallel):
-  Agent(infra-ops)          → runs deployment (uses audit-approved contracts)
-  Agent(frontend-dev)       → scaffolds React app with @onflow/react-sdk
-```
-
-### DeFi protocol from idea to deployed
-```
-Turn 1:
-  Agent(defi-architect)     → produces architecture doc + token model
-
-Turn 2 (parallel):
-  Agent(cadence-specialist) → implements contracts from architecture doc
-  Agent(infra-ops)          → sets up flow.json, emulator config
-
-Turn 3:
-  Agent(auditor)            → reviews all contracts
-
-Turn 4:
-  Agent(infra-ops)          → deploys to testnet
-```
-
-### Audit + fix cycle
-```
-Turn 1:
-  Agent(auditor)            → produces findings with severity ratings
-
-Turn 2:
-  Agent(cadence-specialist) → applies fixes for Critical/High findings
-
-Turn 3:
-  Agent(auditor)            → re-audits changed files only
-```
+| security-auditor + test-architect | ✅ | auditor produces report; test-architect writes test files |
+| storage-architect + cu-profiler | ✅ | architect edits .cdc; profiler only runs CLI commands |
+| cadence-deploy + any writer | ❌ | deploy reads files — writers must finish first |
+| economic-designer + cu-profiler | ❌ | designer needs profiler output |

--- a/plugins/flow-dev/skills/flow-orchestrate/references/task-routing.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/references/task-routing.md
@@ -1,0 +1,98 @@
+# Task Routing — Decision Tree
+
+Use this to determine which agents to spawn and in which order.
+
+## Step 1 — Identify Domains in the Task
+
+Count how many of these domains the task touches:
+
+| # | Domain | Signals |
+|---|---|---|
+| A | Smart contracts | "contract", "cadence", ".cdc", "NFT", "FT", "vault", "resource" |
+| B | Security audit | "audit", "review", "vulnerabilities", "secure", "check my contracts" |
+| C | DeFi / Tokenomics | "DeFi", "AMM", "lending", "tokenomics", "TGE", "veFLOW", "yield" |
+| D | Deploy / CLI / Setup | "deploy", "testnet", "mainnet", "flow.json", "CLI", "emulator", "environment" |
+| E | React frontend | "React", "frontend", "UI", "hooks", "wallet connect", "dapp" |
+
+If only **1 domain** → do NOT use the orchestrator. Route directly to the skill for that domain.
+If **2+ domains** → proceed to Step 2.
+
+## Step 2 — Select Agents
+
+| Task pattern | Agents | Order |
+|---|---|---|
+| New project from scratch | cadence-specialist, infra-ops | parallel |
+| New project + frontend | cadence-specialist, infra-ops, frontend-dev | cadence-specialist ∥ infra-ops, then frontend-dev |
+| Full dapp (contracts + frontend + deploy) | cadence-specialist, auditor, infra-ops, frontend-dev | cadence-specialist → auditor → infra-ops ∥ frontend-dev |
+| DeFi protocol (design + contracts) | defi-architect, cadence-specialist | defi-architect → cadence-specialist |
+| DeFi protocol full launch | defi-architect, cadence-specialist, auditor, infra-ops | defi-architect → cadence-specialist → auditor → infra-ops |
+| Token launch (tokenomics + contracts) | defi-architect, cadence-specialist | defi-architect → cadence-specialist |
+| Audit + fix + redeploy | auditor, cadence-specialist, infra-ops | auditor → cadence-specialist → infra-ops |
+| Existing project: add feature + audit | cadence-specialist, auditor | cadence-specialist → auditor |
+| Setup + scaffold + deploy | infra-ops, cadence-specialist | infra-ops ∥ cadence-specialist, then infra-ops (deploy phase) |
+
+## Step 3 — Refine Each Agent Scope
+
+Before spawning, clarify the exact sub-task for each agent. Agents work best with narrow, concrete instructions:
+
+**Too broad:** "build the contracts"
+**Good:** "Write a Cadence NFT contract implementing NonFungibleToken v2 with MetadataViews.Display and royalties. No admin minting — public open edition. Output to cadence/contracts/MyNFT.cdc"
+
+**Too broad:** "set up the project"
+**Good:** "Initialize flow.json for testnet. Configure the MyNFT contract deployment. Provide the exact `flow project deploy` command. Do NOT write any Cadence code."
+
+## Step 4 — Check for File Conflicts
+
+Agents running in parallel must not write to the same files.
+
+| Agent pair | Safe to parallelize? | Notes |
+|---|---|---|
+| cadence-specialist + defi-architect | ✅ Yes | defi-architect produces a doc; cadence-specialist writes .cdc files |
+| cadence-specialist + frontend-dev | ⚠️ Usually yes | Ensure they target different directories (cadence/ vs. src/) |
+| cadence-specialist + infra-ops | ⚠️ Conditionally | infra-ops touches flow.json; cadence-specialist writes .cdc files — different files, safe |
+| cadence-specialist + auditor | ❌ No | Auditor needs contracts to already exist |
+| auditor + infra-ops | ❌ No | Deploy only after audit approves |
+
+## Common Workflows
+
+### New full-stack Flow dapp
+```
+Turn 1 (parallel):
+  Agent(cadence-specialist) → writes contracts to cadence/
+  Agent(infra-ops)          → writes flow.json, deployment config
+
+Turn 2 (sequential):
+  Agent(auditor)            → reviews cadence/ output from Turn 1
+
+Turn 3 (parallel):
+  Agent(infra-ops)          → runs deployment (uses audit-approved contracts)
+  Agent(frontend-dev)       → scaffolds React app with @onflow/react-sdk
+```
+
+### DeFi protocol from idea to deployed
+```
+Turn 1:
+  Agent(defi-architect)     → produces architecture doc + token model
+
+Turn 2 (parallel):
+  Agent(cadence-specialist) → implements contracts from architecture doc
+  Agent(infra-ops)          → sets up flow.json, emulator config
+
+Turn 3:
+  Agent(auditor)            → reviews all contracts
+
+Turn 4:
+  Agent(infra-ops)          → deploys to testnet
+```
+
+### Audit + fix cycle
+```
+Turn 1:
+  Agent(auditor)            → produces findings with severity ratings
+
+Turn 2:
+  Agent(cadence-specialist) → applies fixes for Critical/High findings
+
+Turn 3:
+  Agent(auditor)            → re-audits changed files only
+```

--- a/plugins/flow-dev/skills/flow-orchestrate/references/task-routing.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/references/task-routing.md
@@ -17,6 +17,20 @@ Maps task keywords to the right agent combination, order, and parallelism.
 If only **1 type** → spawn that single agent directly, no orchestration needed.
 If **2+ types** → proceed to Step 2.
 
+## Phase 0 — Project dependencies (always check first)
+
+Before spawning any agent that reads or writes `.cdc` files, verify the project has
+standard Flow contracts available locally. If `flow.json` does not list
+`NonFungibleToken`, `FungibleToken`, or `MetadataViews` under `dependencies`, run:
+
+```bash
+flow dependencies install
+```
+
+This resolves standard contracts into the project so agents never need to search the
+filesystem. A missing dependency is the most common cause of agents reading files from
+unrelated projects on the same machine.
+
 ## Step 2 — Select workflow
 
 ### New contract from scratch

--- a/plugins/flow-dev/skills/flow-orchestrate/references/task-routing.md
+++ b/plugins/flow-dev/skills/flow-orchestrate/references/task-routing.md
@@ -17,19 +17,26 @@ Maps task keywords to the right agent combination, order, and parallelism.
 If only **1 type** → spawn that single agent directly, no orchestration needed.
 If **2+ types** → proceed to Step 2.
 
-## Phase 0 — Project dependencies (always check first)
+## Phase 0 — Project dependencies (always run first)
 
-Before spawning any agent that reads or writes `.cdc` files, verify the project has
-standard Flow contracts available locally. If `flow.json` does not list
-`NonFungibleToken`, `FungibleToken`, or `MetadataViews` under `dependencies`, run:
+Before spawning any agent that reads or writes `.cdc` files, YOU (the orchestrator)
+must ensure standard contracts are available in the project. Do not ask the user to
+do this — run it yourself:
 
 ```bash
+# Check what dependencies are already declared
+cat flow.json | grep -A5 '"dependencies"'
+
+# Install missing standard contracts into the project
 flow dependencies install
 ```
 
-This resolves standard contracts into the project so agents never need to search the
-filesystem. A missing dependency is the most common cause of agents reading files from
-unrelated projects on the same machine.
+If `flow.json` has no `dependencies` section yet, add the required ones first using
+`flow config add dependency` or by editing `flow.json` directly per the addresses in
+`flow-project-setup/references/configuration.md`, then run `flow dependencies install`.
+
+This resolves NonFungibleToken, FungibleToken, MetadataViews, etc. into the project
+so agents never need to search the filesystem for them.
 
 ## Step 2 — Select workflow
 

--- a/plugins/flow-dev/skills/flow-project-setup/SKILL.md
+++ b/plugins/flow-dev/skills/flow-project-setup/SKILL.md
@@ -25,6 +25,7 @@ flow test              # Run tests
 |------|-----------|
 | flow.json, FCL config, contract addresses, dependencies, CLI commands | [configuration.md](references/configuration.md) |
 | Dev workflow, deployment, debugging, gas optimization, testnet validation | [workflow.md](references/workflow.md) |
+| Allowed/forbidden upgrades, new-name strategy, rollback, multi-contract deploy | [upgrade-strategies.md](references/upgrade-strategies.md) |
 
 ## Companion Skills
 

--- a/plugins/flow-dev/skills/flow-project-setup/references/upgrade-strategies.md
+++ b/plugins/flow-dev/skills/flow-project-setup/references/upgrade-strategies.md
@@ -1,0 +1,112 @@
+# Contract Upgrade Strategies
+
+## What Cadence Allows and Forbids
+
+Cadence enforces upgrade safety at the protocol level. The CLI will reject invalid upgrades.
+
+| Change | Allowed? |
+|--------|----------|
+| Add a new function | ✅ |
+| Change function body (same signature) | ✅ |
+| Add a new field to a struct (with default) | ✅ |
+| Remove a field from a struct or resource | ❌ |
+| Change a field type | ❌ |
+| Remove a public function | ❌ |
+| Change a function signature | ❌ |
+| Add a field to a resource | ❌ (resource storage incompatible) |
+
+Any forbidden change requires deploying under a **new contract name** — existing storage under the old name is abandoned.
+
+## Upgrade Checklist
+
+Before running `flow project deploy` on an existing contract:
+
+```
+[ ] flow project deploy --update --dry-run  (check for rejection before submitting)
+[ ] All changed function signatures are backward-compatible
+[ ] No struct/resource fields removed or retyped
+[ ] New fields on structs have default values in init()
+[ ] Tests pass against the upgraded contract on emulator
+[ ] Testnet deploy verified before mainnet
+```
+
+## New Contract Name Strategy
+
+When a resource schema change is unavoidable:
+
+1. Deploy `MyContractV2` alongside `MyContract` (do not remove the old one).
+2. Write a migration transaction that reads resources from the old path, transforms them, and stores under the new path.
+3. Give users a migration window — document the cutoff block height.
+4. After migration window closes, stop referencing `MyContract` in new transactions.
+
+```cadence
+transaction() {
+    prepare(signer: auth(LoadValue, SaveValue) &Account) {
+        // Load old resource (removes it from storage)
+        let old <- signer.storage.load<@MyContract.OldResource>(from: /storage/myResource)
+            ?? panic("nothing to migrate")
+
+        // Transform and save under new contract type
+        let new <- MyContractV2.wrap(legacy: <- old)
+        signer.storage.save(<-new, to: /storage/myResourceV2)
+    }
+}
+```
+
+## Testnet Validation Before Mainnet
+
+Always deploy to testnet first and run the full post-deploy checklist:
+
+```bash
+flow project deploy --network testnet
+
+# Smoke test: read initialized state
+flow scripts execute cadence/scripts/GetState.cdc --network testnet
+
+# Write test: confirm a transaction seals
+flow transactions send cadence/transactions/Ping.cdc --network testnet --signer testnet-account
+
+# Verify round-trip
+flow scripts execute cadence/scripts/GetState.cdc --network testnet
+```
+
+Only promote to mainnet after all three steps pass.
+
+## Rollback
+
+Cadence has no rollback. Once a contract is deployed to mainnet it cannot be removed, only updated (within the allowed changes above).
+
+Mitigation strategies:
+- **Admin pause function**: include an `access(Admin) fun pause()` that gates all state-mutating functions behind a boolean. Deploy with `paused = false`. If a bug is found, call pause to stop damage while a fix is prepared.
+- **Emergency contact**: document an on-call address that holds the admin capability.
+
+```cadence
+access(all) resource Admin {
+    access(all) fun pause() {
+        MyContract.paused = true
+    }
+    access(all) fun unpause() {
+        MyContract.paused = false
+    }
+}
+
+access(all) fun assertNotPaused() {
+    assert(!MyContract.paused, message: "contract is paused")
+}
+```
+
+Add `assertNotPaused()` as the first line of every state-mutating function.
+
+## Multi-Contract Coordinated Deploy
+
+When deploying multiple interdependent contracts, order matters — dependencies must be deployed first.
+
+```json
+"deployments": {
+  "testnet": {
+    "testnet-account": ["FungibleToken", "FlowToken", "MyToken", "MyDEX"]
+  }
+}
+```
+
+`flow project deploy` resolves this order automatically from the import graph. If a contract fails mid-deploy, the remaining contracts are not deployed — fix the error and re-run. Partial deploys do not need manual cleanup because the failed contract simply isn't on-chain yet.


### PR DESCRIPTION
## Summary

Adds a `flow-orchestrate` skill that routes complex, multi-domain Flow development tasks to specialized subagents. Each agent receives only the reference files for its domain — keeping per-agent context 80-90% leaner than loading all 50 reference files.

Validated end-to-end: a single prompt produced a production-ready NFT contract, passed a security audit (2 High findings found and fixed), deployed to emulator, profiled CU across N=10–1000, and computed a governance-updatable mint fee — all without manual coding. See [claucondor/flow-orchestator-test](https://github.com/claucondor/flow-orchestator-test).

## Requirements

| Mode | What it uses | Requirement |
|---|---|---|
| Pipeline (most tasks) | parallel `Agent()` calls, sequential handoffs | none — works out of the box |
| Team mode (back-and-forth cycles) | `TeamCreate` + `SendMessage` peer-to-peer | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` in `~/.claude/settings.json` |

The orchestrator detects which mode to use based on task complexity and documents the check command inline in SKILL.md. Most workflows run as a pipeline and need no flag.

## What's included

`flow-orchestrate/SKILL.md` — orchestrator briefing: agent roster with capabilities and limitations, plugin root resolution, workspace scoping, parallel vs sequential rules, Team vs subagent decision criteria, experimental flag requirement, plan announcement format.

`flow-orchestrate/agents/` — 8 agent templates:

| Agent | Domain |
|---|---|
| `cu-profiler` | CU cost measurement via testnet sweep |
| `storage-architect` | Cadence resource layout optimization |
| `cross-vm-bridge` | Cadence↔EVM boundary (COA, ABI encoding, dryCall) |
| `cadence-deploy` | compile → deploy → verify cycle |
| `economic-designer` | fees, treasury design, solvency analysis |
| `security-auditor` | vulnerability audit with severity-rated findings |
| `test-architect` | CDC native + Go/overflow test suites |
| `frontend-dev` | React UI with @onflow/react-sdk |

Each template: role, when-to-spawn criteria, refs to embed, full prompt with embedded domain knowledge, team peer-routing (who sends what to whom), token budget.

`flow-orchestrate/references/task-routing.md` — decision tree: task keywords → agent sets, Phase 0 dependency install, parallel/sequential ordering, file conflict detection.

`flow-orchestrate/references/handoff-format.md` — structured output each agent must produce so downstream agents consume results without re-reading everything.

New cross-skill references:
- `cadence-lang/references/cu-optimization.md` — CU cost table, high-CU patterns, MAX_SAFE_N methodology
- `flow-dev-setup/references/testing-patterns.md` — CDC native vs Go/overflow decision tree, adversarial test categories
- `flow-project-setup/references/upgrade-strategies.md` — allowed/forbidden upgrades, new-name migration, rollback
- `flow-defi/references/protocol-architecture.md` — appended cross-VM failure modes

## Design decisions

**Phase 0 always runs first.** The orchestrator runs `flow dependencies install` before any agent touches `.cdc` files. Agents never search the filesystem for standard contracts.

**Project root is explicit in every agent prompt.** Prevents agents from reading files from unrelated projects on the same machine.

**Agent templates are a base, not a fixed list.** Orchestrator adds cadence-scaffold refs when generating new code, and domain refs (access-control, transactions) when the task calls for it.

## Test run

[claucondor/flow-orchestator-test](https://github.com/claucondor/flow-orchestator-test) — 7 commits tracing each agent's output, 176 tool calls, ~22 min. CU model: `CU(N) = 4.46N + 9.68` (R²=0.9999), MAX_SAFE_N=2013, MINT_FEE=0.00000025 FLOW.