### PR TITLE
Document Cadence generated code expectations

### DIFF
--- a/plugins/flow-dev/skills/cadence-lang/SKILL.md
+++ b/plugins/flow-dev/skills/cadence-lang/SKILL.md
@@ -16,6 +16,16 @@ Write secure, correct Cadence code by following these rules. Cadence uses resour
 2. **Resource safety** — resources exist in one place, must be explicitly moved (`<-`) or destroyed
 3. **Capability-based security** — access delegated through unforgeable, revocable capabilities
 4. **Explicit over implicit** — force developers to make security decisions
+5. **Document generated code** — add Cadence doc comments for public-facing types and functions, plus focused inline comments for non-obvious logic and security decisions
+
+## Documentation Rules
+
+When you generate or rewrite Cadence code:
+
+- Add doc comments (`///`) to contracts, resources, structs, events, and functions that a reader needs to understand or call.
+- Describe purpose and behavior, not syntax. Mention invariants, access assumptions, or side effects when they matter.
+- Add inline `//` comments inside function bodies for non-obvious logic, phase boundaries, resource moves, capability usage, and security-sensitive checks.
+- Do not spam comments on trivial statements. Prefer a few high-signal comments over line-by-line narration.
 
 ## Navigation Map
 

--- a/plugins/flow-dev/skills/cadence-lang/SKILL.md
+++ b/plugins/flow-dev/skills/cadence-lang/SKILL.md
@@ -16,16 +16,7 @@ Write secure, correct Cadence code by following these rules. Cadence uses resour
 2. **Resource safety** — resources exist in one place, must be explicitly moved (`<-`) or destroyed
 3. **Capability-based security** — access delegated through unforgeable, revocable capabilities
 4. **Explicit over implicit** — force developers to make security decisions
-5. **Document generated code** — add Cadence doc comments for public-facing types and functions, plus focused inline comments for non-obvious logic and security decisions
-
-## Documentation Rules
-
-When you generate or rewrite Cadence code:
-
-- Add doc comments (`///`) to contracts, resources, structs, events, and functions that a reader needs to understand or call.
-- Describe purpose and behavior, not syntax. Mention invariants, access assumptions, or side effects when they matter.
-- Add inline `//` comments inside function bodies for non-obvious logic, phase boundaries, resource moves, capability usage, and security-sensitive checks.
-- Do not spam comments on trivial statements. Prefer a few high-signal comments over line-by-line narration.
+5. **Document generated code** — follow the Cadence documentation conventions in the relevant reference docs
 
 ## Navigation Map
 
@@ -37,6 +28,7 @@ Read the relevant reference file based on your task:
 | Resource lifecycle, move operator | [resources.md](references/resources.md) |
 | Contract structure, init, deployment | [contracts.md](references/contracts.md) |
 | Transaction phases, entitlements | [transactions.md](references/transactions.md) |
+| Documentation conventions | [documentation.md](references/documentation.md) |
 | Interfaces, intersection types | [interfaces.md](references/interfaces.md) |
 | Account storage, keys, capabilities | [accounts.md](references/accounts.md) |
 | References, authorized refs | [references.md](references/references.md) |

--- a/plugins/flow-dev/skills/cadence-lang/references/documentation.md
+++ b/plugins/flow-dev/skills/cadence-lang/references/documentation.md
@@ -1,0 +1,46 @@
+# Cadence Documentation Conventions
+
+Generated Cadence code should be documented, especially when it introduces new contract APIs or non-obvious logic.
+
+## What Must Be Documented
+
+- Add doc comments (`///`) to contracts, resources, structs, resource interfaces, struct interfaces, and events when they are part of the design a reader needs to understand.
+- Add doc comments (`///`) to callable functions, especially public or entitled functions that other code or users are expected to call.
+- Keep the focus on types and functions first. That is the minimum bar for generated code.
+
+## How To Write Doc Comments
+
+- Describe purpose and behavior, not syntax.
+- Mention invariants, side effects, entitlement requirements, or important preconditions when they matter to safe usage.
+- Keep comments concise and directly above the declaration they describe.
+
+```cadence
+/// Tracks escrow state and releases payment only after delivery is confirmed.
+access(all) contract Escrow {
+    /// Emits when escrowed funds are released to the seller.
+    access(all) event PaymentReleased(amount: UFix64, seller: Address)
+
+    /// Releases escrowed funds after the contract has verified delivery.
+    access(ReleasePayment) fun releasePayment(): UFix64 {
+        // ...
+    }
+}
+```
+
+## Inline Comments In Function Bodies
+
+- Add focused `//` comments for non-obvious logic inside function bodies.
+- Use them to explain phase boundaries, resource movement, capability usage, security-sensitive checks, and invariant enforcement.
+- Do not narrate trivial statements line by line.
+
+```cadence
+access(all) fun fulfill(orderID: UInt64) {
+    // Borrow instead of load/save so the resource stays in account storage.
+    let escrow = self.orders[orderID]
+        ?? panic("Order with ID \(orderID) not found")
+
+    // Mark delivered before release so the post-state matches the payment guard.
+    escrow.markDelivered()
+    self.releaseEscrow(orderID: orderID)
+}
+```

--- a/plugins/flow-dev/skills/cadence-lang/references/documentation.md
+++ b/plugins/flow-dev/skills/cadence-lang/references/documentation.md
@@ -12,8 +12,8 @@ Generated Cadence code should be documented, especially when it introduces new c
 ## Markdown Support
 
 - Cadence doc comments support Markdown. Use standard Markdown formatting when it improves readability.
-- Prefer `**bold labels**`, bullet lists, and inline code over ad hoc annotation syntax.
-- Do not use `@param` or `@return`. The reviewed PR discussion explicitly rejects that format because the LSP does not render it well.
+- Use inline code, emphasis, and bullet lists where they improve readability.
+- Keep Markdown simple so generated documentation remains structured and readable.
 
 ## How To Write Doc Comments
 
@@ -40,30 +40,36 @@ access(all) contract Escrow {
 Function documentation has three parts, in order:
 
 1. Description: one or more sentences explaining what the function does. If the function can panic or has caller-visible side effects, say so here.
-2. `**Parameters**` block: only include this when the function takes parameters. Put `**Parameters**` on its own doc-comment line, then add one bullet per parameter using inline code for the parameter name followed by its description.
-3. `**Returns**` block: only include this when the function returns a non-`Void` value. Put `**Returns**` inline with a prose description of the returned value.
+2. Parameter tags: when the function takes parameters, document each one with `@param`, followed by the parameter name, a colon, and the parameter description.
+3. Return tag: when the function returns a non-`Void` value, document it with `@return`, followed by a prose description of the returned value.
 
 Separate blocks with blank doc-comment lines.
 
 ```cadence
-/// Consumes one unit of allowance and creates a new yield vault.
-/// Panics if allowance is exhausted.
+/// This is the description of the function. This function adds two values.
 ///
-/// **Parameters**
-/// - `name`: Name of the registered strategy to create a vault for.
+/// @param a: First integer value to add
+/// @param b: Second integer value to add
+/// @return Addition of the two arguments `a` and `b`
 ///
-/// **Returns** A new `YieldVault` to be saved in the caller's storage.
-access(all) fun createYieldVault(name: String): @{FlowYieldVaultsInterfaces.YieldVault} {
+access(all) fun add(a: Int, b: Int): Int {
     // ...
 }
 ```
 
-For short functions where the description already explains the parameters and return value in prose, the `**Parameters**` and `**Returns**` blocks can be omitted.
+Do not mix description text with parameter or return documentation after the tags have started.
 
 ```cadence
-/// Returns `|numer - denom| / denom`, or `0.0` when `denom = 0`.
-/// Used to compare `|1 - (numer / denom)|` without `UFix64` underflow.
-view access(all) fun absDeviationFromOne(_ numer: UFix64, _ denom: UFix64): UFix64 {
+/// This is the description of the function.
+///
+/// @param a: First integer value to add
+/// @param b: Second integer value to add
+///
+/// This function adds two values. However, this is not the proper way to document it.
+/// This part of the description is not in the proper place.
+///
+/// @return Addition of the two arguments `a` and `b`
+access(all) fun add(a: Int, b: Int): Int {
     // ...
 }
 ```
@@ -88,7 +94,7 @@ access(all) fun fulfill(orderID: UInt64) {
 
 ## Best Practices
 
-- Avoid Markdown headings (`#`, `##`) and horizontal rules inside doc comments. Use `**Parameters**` and `**Returns**` when you need section-like structure.
-- Keep the description at the top. Do not interleave description text with the `**Parameters**` or `**Returns**` blocks.
-- Put `**Returns**` after `**Parameters**`.
-- When a function panics, say so in the description instead of inventing a separate panic block.
+- Avoid headings and horizontal rules inside doc comments. The `docgen` README warns they can conflict with generated output structure.
+- Keep the function description at the top and keep `@param` / `@return` documentation grouped below it.
+- Use inline code when referring to identifiers such as parameter names and function names.
+- When a function panics, say so in the description.

--- a/plugins/flow-dev/skills/cadence-lang/references/documentation.md
+++ b/plugins/flow-dev/skills/cadence-lang/references/documentation.md
@@ -4,15 +4,23 @@ Generated Cadence code should be documented, especially when it introduces new c
 
 ## What Must Be Documented
 
-- Add doc comments (`///`) to contracts, resources, structs, resource interfaces, struct interfaces, and events when they are part of the design a reader needs to understand.
-- Add doc comments (`///`) to callable functions, especially public or entitled functions that other code or users are expected to call.
+- Add doc comments to contracts, resources, structs, resource interfaces, struct interfaces, fields, functions, and events when they are part of the design a reader needs to understand.
+- Doc comments may use `///` line comments or `/** ... */` block comments. Prefer `///` for generated code unless there is a clear reason to use block comments.
+- Add doc comments to callable functions, especially public or entitled functions that other code or users are expected to call.
 - Keep the focus on types and functions first. That is the minimum bar for generated code.
+
+## Markdown Support
+
+- Cadence doc comments support Markdown. Use standard Markdown formatting when it improves readability.
+- Prefer `**bold labels**`, bullet lists, and inline code over ad hoc annotation syntax.
+- Do not use `@param` or `@return`. The reviewed PR discussion explicitly rejects that format because the LSP does not render it well.
 
 ## How To Write Doc Comments
 
 - Describe purpose and behavior, not syntax.
-- Mention invariants, side effects, entitlement requirements, or important preconditions when they matter to safe usage.
+- Mention invariants, side effects, entitlement requirements, important preconditions, and panic conditions when they matter to safe usage.
 - Keep comments concise and directly above the declaration they describe.
+- Use backticks for identifiers such as function names, parameter names, types, fields, and entitlements.
 
 ```cadence
 /// Tracks escrow state and releases payment only after delivery is confirmed.
@@ -24,6 +32,39 @@ access(all) contract Escrow {
     access(ReleasePayment) fun releasePayment(): UFix64 {
         // ...
     }
+}
+```
+
+## Function Documentation Format
+
+Function documentation has three parts, in order:
+
+1. Description: one or more sentences explaining what the function does. If the function can panic or has caller-visible side effects, say so here.
+2. `**Parameters**` block: only include this when the function takes parameters. Put `**Parameters**` on its own doc-comment line, then add one bullet per parameter using inline code for the parameter name followed by its description.
+3. `**Returns**` block: only include this when the function returns a non-`Void` value. Put `**Returns**` inline with a prose description of the returned value.
+
+Separate blocks with blank doc-comment lines.
+
+```cadence
+/// Consumes one unit of allowance and creates a new yield vault.
+/// Panics if allowance is exhausted.
+///
+/// **Parameters**
+/// - `name`: Name of the registered strategy to create a vault for.
+///
+/// **Returns** A new `YieldVault` to be saved in the caller's storage.
+access(all) fun createYieldVault(name: String): @{FlowYieldVaultsInterfaces.YieldVault} {
+    // ...
+}
+```
+
+For short functions where the description already explains the parameters and return value in prose, the `**Parameters**` and `**Returns**` blocks can be omitted.
+
+```cadence
+/// Returns `|numer - denom| / denom`, or `0.0` when `denom = 0`.
+/// Used to compare `|1 - (numer / denom)|` without `UFix64` underflow.
+view access(all) fun absDeviationFromOne(_ numer: UFix64, _ denom: UFix64): UFix64 {
+    // ...
 }
 ```
 
@@ -44,3 +85,10 @@ access(all) fun fulfill(orderID: UInt64) {
     self.releaseEscrow(orderID: orderID)
 }
 ```
+
+## Best Practices
+
+- Avoid Markdown headings (`#`, `##`) and horizontal rules inside doc comments. Use `**Parameters**` and `**Returns**` when you need section-like structure.
+- Keep the description at the top. Do not interleave description text with the `**Parameters**` or `**Returns**` blocks.
+- Put `**Returns**` after `**Parameters**`.
+- When a function panics, say so in the description instead of inventing a separate panic block.

--- a/plugins/flow-dev/skills/cadence-scaffold/SKILL.md
+++ b/plugins/flow-dev/skills/cadence-scaffold/SKILL.md
@@ -29,8 +29,6 @@ All generated code must follow:
 4. Descriptive panic messages with interpolated values
 5. Events for significant state changes
 6. Complete `init()` with all state initialized
-7. Doc comments (`///`) on the generated types and callable functions
-8. Inline `//` comments in function bodies where logic, resource movement, or security decisions are non-obvious
 
 ## Companion Skills
 

--- a/plugins/flow-dev/skills/cadence-scaffold/SKILL.md
+++ b/plugins/flow-dev/skills/cadence-scaffold/SKILL.md
@@ -29,6 +29,8 @@ All generated code must follow:
 4. Descriptive panic messages with interpolated values
 5. Events for significant state changes
 6. Complete `init()` with all state initialized
+7. Doc comments (`///`) on the generated types and callable functions
+8. Inline `//` comments in function bodies where logic, resource movement, or security decisions are non-obvious
 
 ## Companion Skills
 

--- a/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-contract.md
+++ b/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-contract.md
@@ -116,6 +116,9 @@ If the contract is a fungible token, also:
 
 ## Post-Generation
 
-After generating, add inline comments explaining security decisions for each access modifier and entitlement choice.
+After generating:
+- Add `///` doc comments for the contract, each public-facing resource/struct/event, and each externally callable function.
+- Add inline comments explaining security decisions for each access modifier and entitlement choice.
+- Add inline comments anywhere resource movement, capability publication, or invariant enforcement would otherwise be hard to follow.
 
 > **See also:** `cadence-lang` skill → `access-control.md` and `entitlements.md` for access rules, `design-patterns.md` for naming and storage patterns, `anti-patterns.md` for what to avoid. For NFT contracts, see `cadence-tokens` skill → `nft-standards.md`. Use `cadence-audit` skill to review generated code before deployment. Use `flow-cli` skill to deploy with `flow accounts add-contract`.

--- a/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-contract.md
+++ b/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-contract.md
@@ -121,4 +121,4 @@ After generating:
 - Add inline comments explaining security decisions for each access modifier and entitlement choice.
 - Add inline comments anywhere resource movement, capability publication, or invariant enforcement would otherwise be hard to follow.
 
-> **See also:** `cadence-lang` skill → `access-control.md` and `entitlements.md` for access rules, `design-patterns.md` for naming and storage patterns, `anti-patterns.md` for what to avoid. For NFT contracts, see `cadence-tokens` skill → `nft-standards.md`. Use `cadence-audit` skill to review generated code before deployment. Use `flow-cli` skill to deploy with `flow accounts add-contract`.
+> **See also:** `cadence-lang` skill → `documentation.md` for docstring and inline comment conventions, `access-control.md` and `entitlements.md` for access rules, `design-patterns.md` for naming and storage patterns, `anti-patterns.md` for what to avoid. For NFT contracts, see `cadence-tokens` skill → `nft-standards.md`. Use `cadence-audit` skill to review generated code before deployment. Use `flow-cli` skill to deploy with `flow accounts add-contract`.

--- a/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-defi.md
+++ b/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-defi.md
@@ -117,3 +117,5 @@ After generating, add comments explaining:
 - Intent and safety rationale for each connector
 - Why token order was reversed (if applicable)
 - What the post-condition verifies
+
+Also add `///` doc comments for the transaction and helper functions so the generated code is self-documenting.

--- a/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-defi.md
+++ b/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-defi.md
@@ -119,3 +119,5 @@ After generating, add comments explaining:
 - What the post-condition verifies
 
 Also add `///` doc comments for the transaction and helper functions so the generated code is self-documenting.
+
+See `cadence-lang` skill → `documentation.md` for the expected docstring and inline comment conventions.

--- a/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-transaction.md
+++ b/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-transaction.md
@@ -111,4 +111,4 @@ After generating, add inline comments explaining:
 
 Also add `///` doc comments for the transaction and any helper functions so the intent and call expectations are explicit.
 
-> **See also:** `cadence-lang` skill → `transactions.md` for phase rules, `entitlements.md` for account entitlement patterns, `conditions.md` for pre/post condition syntax, `capabilities.md` for capability setup patterns. Use `flow-cli` skill to test with `flow transactions send`.
+> **See also:** `cadence-lang` skill → `documentation.md` for docstring and inline comment conventions, `transactions.md` for phase rules, `entitlements.md` for account entitlement patterns, `conditions.md` for pre/post condition syntax, `capabilities.md` for capability setup patterns. Use `flow-cli` skill to test with `flow transactions send`.

--- a/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-transaction.md
+++ b/plugins/flow-dev/skills/cadence-scaffold/references/scaffold-transaction.md
@@ -109,4 +109,6 @@ After generating, add inline comments explaining:
 - What each phase does
 - Security rationale for access patterns
 
+Also add `///` doc comments for the transaction and any helper functions so the intent and call expectations are explicit.
+
 > **See also:** `cadence-lang` skill → `transactions.md` for phase rules, `entitlements.md` for account entitlement patterns, `conditions.md` for pre/post condition syntax, `capabilities.md` for capability setup patterns. Use `flow-cli` skill to test with `flow transactions send`.


### PR DESCRIPTION
## Summary
- require the cadence-lang skill to generate documented Cadence code
- require scaffolded Cadence output to include doc comments and focused inline comments
- extend scaffold reference guidance so contracts, transactions, and DeFi templates all call for self-documenting generated code

## Testing
- not run (pytest is not installed in this environment)

Closes #26