### PR TITLE
Add real-world hardening patterns to existing skills

### DIFF
--- a/plugins/flow-dev/skills/cadence-audit/references/audit-checklist.md
+++ b/plugins/flow-dev/skills/cadence-audit/references/audit-checklist.md
@@ -126,6 +126,63 @@
 - Verify complete transfers (assert residual balance == 0.0)
 - Size withdrawals by sink capacity when immediately depositing
 
+## Cross-VM and DeFi Advanced Checks
+
+### Stuck State / Missing Emergency Exit
+- Does any `burnCallback` or `closeCallback` assert against an external system (EVM vault, bridge, oracle)?
+- If that external system fails permanently, can the vault ever be closed? Is there an admin emergency exit with a grace period (e.g., >7 days stuck → force close allowed)?
+- Pattern: `assert(pendingRedeem == nil)` in `burnCallback` but `clearRedeemRequest` also calls EVM → if EVM is paused, both paths fail and funds are trapped.
+
+### Cross-VM Timing Races
+- Is the timelock snapshot taken at `requestRedeem` time and never re-queried?
+- If the EVM vault admin changes the timelock after the request but before `claimRedeem`, the scheduled timestamp is stale.
+- Fix: re-query current EVM timelock at claim time and use `max(scheduledTimestamp, currentTime + newTimelock)`.
+
+### Lingering EVM Approvals
+- After a successful `claimRedeem`, is the ERC20 approval (`approve(spender, amount)`) revoked?
+- ERC4626 `redeem()` does not consume ERC20 allowance — if not revoked, future shares in the same vault + compromised COA = unauthorized redemption.
+- Fix: call `_evmApprove(spender, amount: 0)` immediately after successful `claimRedeem`.
+
+### EVM Call Result Not Validated
+- Every `coa.call()` and `EVM.dryCall()` returns `EVM.Result`. Is `result.status == EVM.Status.successful` checked before trusting `result.data`?
+- Unchecked EVM failure = silent state divergence between Cadence and EVM.
+
+### Bridge Precision Loss (UFix64 ↔ uint256)
+- UFix64 has 8 decimal places. EVM ERC20 tokens typically use 18. Conversion without explicit ×10^10 scaling truncates or inflates amounts.
+- Dust accumulates across calls into exploitable value at volume.
+- Fix: explicit scaling on every Cadence↔EVM conversion. Round against the user (floor on deposit, ceiling on withdrawal).
+- HackenProof Flow bug bounty classifies this as Critical.
+
+### Fixed-Point Overflow in AMM Liquidity (Cetus-class)
+- Cetus DEX (Sui, May 2025, $223M): unchecked bit-shift in liquidity delta math. Same pattern applies to any Cadence AMM with custom fixed-point scaling.
+- Does any bit-shift or scaling operation have a correct bit-width guard (not just value bounds)?
+- Can a flash-add max liquidity + immediate remove expose a divergence between deposit requirement and withdrawal entitlement?
+
+### access(account) Co-Deploy Escalation
+- `access(account)` exposes fields to ALL contracts on the same Flow account.
+- A future contract upgrade on that account (or compromised key) gains full read/write access to all `access(account)` state across every co-deployed contract.
+- Dec 27, 2025 exploit deployed ~40 malicious contracts to amplify this vector.
+- Audit: enumerate all `access(account)` fields. Verify all contracts on that account are equally trusted. Verify upgrade requires multi-sig.
+
+### Burnable.burnCallback() Griefing via External Token
+- Any protocol that accepts arbitrary `FungibleToken` vaults and destroys them can be griefed by a token whose `burnCallback()` panics or executes unexpected state changes inside the protocol's own transaction.
+- Is `Burner.burn(<-vault)` called on vaults received from external sources without type verification?
+- Fix: only destroy vaults of explicitly allowlisted token types. Never call `Burner.burn()` on caller-supplied vaults without type verification.
+
+### Cross-VM Bridge as Exploit Exit — No Rate Limit
+- Dec 27, 2025 ($3.9M): attacker minted counterfeit FLOW → bridged to Flow EVM → bridged to Ethereum before validators halted. All in one block sequence.
+- Does the protocol interact with the EVM bridge? Is there a per-block or per-transaction volume cap? Is there an admin pause callable within seconds?
+- Any mint/inflate exploit can exit via the bridge faster than governance can react.
+
+### Contract Initializer Argument Type Smuggling
+- Dec 27, 2025: `account.contracts.add()` accepted arguments where calling context treated them as value types but initializer treated them as resources → resources copied instead of moved → infinite mint. Patched in Cadence v1.8.9.
+- Audit: any deployment/upgrade transaction that passes attachments, `PublicKey` wrappers, or nested composites as initializer arguments. Verify static type == dynamic type for all complex arguments.
+
+### Use-After-Free via Retained Reference After Resource Destroy
+- Halborn 2021: Cadence allowed method calls on a resource reference after the resource was destroyed. Runtime-patched.
+- In multi-contract systems: if contract A holds a borrowed reference from contract B's storage, and B destroys the resource via a separate path, the reference in A is stale.
+- Verify no live cross-contract reference exists to a resource before it is destroyed.
+
 ## Optimization
 
 ### Storage Operations

--- a/plugins/flow-dev/skills/cadence-audit/references/audit-checklist.md
+++ b/plugins/flow-dev/skills/cadence-audit/references/audit-checklist.md
@@ -130,18 +130,18 @@
 
 ### Stuck State / Missing Emergency Exit
 - Does any `burnCallback` or `closeCallback` assert against an external system (EVM vault, bridge, oracle)?
-- If that external system fails permanently, can the vault ever be closed? Is there an admin emergency exit with a grace period (e.g., >7 days stuck → force close allowed)?
-- Pattern: `assert(pendingRedeem == nil)` in `burnCallback` but `clearRedeemRequest` also calls EVM → if EVM is paused, both paths fail and funds are trapped.
+- If that external system fails permanently, can the vault ever be closed? Is there an admin emergency exit with a grace period (e.g., >7 days stuck → force close)?
+- Pattern: closing a vault asserts a pending operation is nil, but cancelling that operation also calls EVM → if EVM is paused, both close and cancel fail, funds are permanently trapped.
 
 ### Cross-VM Timing Races
-- Is the timelock snapshot taken at `requestRedeem` time and never re-queried?
-- If the EVM vault admin changes the timelock after the request but before `claimRedeem`, the scheduled timestamp is stale.
-- Fix: re-query current EVM timelock at claim time and use `max(scheduledTimestamp, currentTime + newTimelock)`.
+- In deferred operations (request phase → claim phase): is the timelock or deadline captured once at request time and never re-queried?
+- If the external system changes its timelock after the request but before the claim, the stored timestamp is stale — claim executes too early (EVM reverts) or too late (user waits unnecessarily).
+- Fix: re-query the current external timelock at claim time and use `max(storedTimestamp, currentTime + currentTimelock)`.
 
 ### Lingering EVM Approvals
-- After a successful `claimRedeem`, is the ERC20 approval (`approve(spender, amount)`) revoked?
-- ERC4626 `redeem()` does not consume ERC20 allowance — if not revoked, future shares in the same vault + compromised COA = unauthorized redemption.
-- Fix: call `_evmApprove(spender, amount: 0)` immediately after successful `claimRedeem`.
+- After completing an EVM-side redemption or transfer, is the ERC20 approval (`approve(spender, amount)`) explicitly revoked?
+- ERC4626 `redeem()` does not consume ERC20 allowance — an unrewoked approval persists. If the user later deposits more shares and the spender COA is compromised, unauthorized redemption becomes possible.
+- Fix: send a zero-approval call immediately after a successful EVM redemption completes.
 
 ### EVM Call Result Not Validated
 - Every `coa.call()` and `EVM.dryCall()` returns `EVM.Result`. Is `result.status == EVM.Status.successful` checked before trusting `result.data`?

--- a/plugins/flow-dev/skills/cadence-lang/SKILL.md
+++ b/plugins/flow-dev/skills/cadence-lang/SKILL.md
@@ -39,6 +39,7 @@ Read the relevant reference file based on your task:
 | Security best practices | [security-best-practices.md](references/security-best-practices.md) |
 | Anti-patterns to avoid | [anti-patterns.md](references/anti-patterns.md) |
 | Design patterns | [design-patterns.md](references/design-patterns.md) |
+| CU cost by operation, optimization patterns, MAX_SAFE_N methodology | [cu-optimization.md](references/cu-optimization.md) |
 
 For security-sensitive tasks, also read `security-best-practices.md` and `anti-patterns.md`.
 

--- a/plugins/flow-dev/skills/cadence-lang/references/anti-patterns.md
+++ b/plugins/flow-dev/skills/cadence-lang/references/anti-patterns.md
@@ -125,6 +125,56 @@ access(all) resource Minter {
 
 Similarly, avoid emitting events from struct initializers.
 
+## Anti-Pattern 6: access(account) in Multi-Contract Accounts
+
+**Problem**: `access(account)` grants access to ALL contracts on the same Flow account — not just the declaring contract. A future contract upgrade or compromised key exposes all `access(account)` state.
+
+```cadence
+// ❌ Any contract on this account can read/write this field
+access(account) var totalSupply: UFix64
+access(account) var adminNonce: UInt64
+```
+
+**Real-world risk**: Dec 27, 2025 exploit deployed malicious contracts to an account to amplify access. If sensitive state is `access(account)`, any co-deployed contract is a lateral movement path.
+
+**Fix**: Prefer `access(self)` for fields that only the declaring contract needs. Use `access(account)` only when cross-contract access within the account is genuinely required AND all co-deployed contracts are equally trusted.
+```cadence
+// ✅ Only this contract can access
+access(self) var totalSupply: UFix64
+
+// ✅ If cross-contract access is needed, document why and what contracts share the account
+access(account) var sharedNonce: UInt64  // Shared with ContractB on same account (multi-sig upgrades only)
+```
+
+**Audit**: For every `access(account)` field, list which contracts share the account and whether any of them can be upgraded independently.
+
+## Anti-Pattern 7: Burner.burn() on External Token Vaults
+
+**Problem**: Accepting arbitrary `FungibleToken` vaults and destroying them via `Burner.burn()` lets an attacker grief the protocol with a malicious `burnCallback()`.
+
+```cadence
+// ❌ burnCallback() of unknown token type runs in THIS transaction
+access(all) fun rejectDeposit(vault: @{FungibleToken.Vault}) {
+    Burner.burn(<-vault)  // Attacker controls burnCallback — can panic or modify state
+}
+```
+
+**Why dangerous**: Cadence 1.0 `Burner.Burnable` interface lets any token define custom logic on destruction. A maliciously crafted token's `burnCallback()` runs inside the protocol's transaction context, potentially causing panic (DoS) or unexpected state changes.
+
+**Fix**: Validate token type against an allowlist before destroying. Return rejected vaults to the sender rather than destroying them.
+```cadence
+// ✅ Only destroy known, trusted token types
+access(all) fun rejectDeposit(vault: @{FungibleToken.Vault}) {
+    assert(vault.isInstance(Type<@FlowToken.Vault>()), message: "Unsupported token type")
+    Burner.burn(<-vault)
+}
+
+// ✅ Even better: return instead of destroy
+access(all) fun rejectDeposit(vault: @{FungibleToken.Vault}): @{FungibleToken.Vault} {
+    return <-vault  // Caller handles disposal
+}
+```
+
 ## Detection Checklist
 
 - [ ] Functions accepting `auth(...) &Account` parameters
@@ -134,3 +184,5 @@ Similarly, avoid emitting events from struct initializers.
 - [ ] State modifications in struct initializers
 - [ ] Event emissions in struct initializers
 - [ ] Over-use of `access(all)` modifier
+- [ ] `access(account)` fields without documenting which co-deployed contracts share the account
+- [ ] `Burner.burn()` called on externally-supplied vaults without token type validation

--- a/plugins/flow-dev/skills/cadence-lang/references/cu-optimization.md
+++ b/plugins/flow-dev/skills/cadence-lang/references/cu-optimization.md
@@ -1,0 +1,126 @@
+# Cadence CU Optimization
+
+Flow hard-caps every transaction at **9,999 CU**. Fees have two components:
+- Inclusion fee: 0.0001 FLOW (fixed)
+- Execution fee: CU × price_per_CU (≈ 4.0e-5 FLOW/CU)
+
+Extract real CU from the `FlowFees.FeesDeducted` event `amount` field after any sealed transaction.
+
+## CU Cost by Operation Type
+
+| Operation | CU cost | Notes |
+|-----------|---------|-------|
+| FT transfer (reference) | ~19 CU | Baseline for fee math |
+| `{UInt64: T}` dict write | ~7–8 CU | 2 hash passes + B+ tree traversal |
+| `[T]` array append | ~0.3–0.5 CU | Bounds check only |
+| `account.storage.borrow<&T>` | ~5 CU | Charged even if resource unchanged |
+| `StoragePath(identifier: s)` construction | ~1 CU | String allocation |
+| EVM `dryCall` (simple view) | ~50–100 CU | Varies with return data size |
+| EVM `coa.call` (state mutating) | ~200–500 CU | Plus EVM gas converted to CU |
+
+## High-CU Patterns to Avoid
+
+**Dict writes inside loops**
+```cadence
+// ❌ 7–8 CU per iteration
+for id in ids {
+    self.registry[id] = value
+}
+
+// ✅ ~0.4 CU per iteration — use array if keyed access not needed
+self.items.append(value)
+```
+
+**Borrow inside loops**
+```cadence
+// ❌ ~5 CU wasted per iteration even if resource unchanged
+for i in items {
+    let r = self.account.storage.borrow<&Counter>(from: /storage/counter)!
+    r.increment()
+}
+
+// ✅ borrow once, use reference for all iterations
+let counter = self.account.storage.borrow<&Counter>(from: /storage/counter)!
+for i in items {
+    counter.increment()
+}
+```
+
+**Path construction inside loops**
+```cadence
+// ❌ ~1 CU per iteration
+for id in ids {
+    let path = StoragePath(identifier: "vault_".concat(id.toString()))!
+}
+
+// ✅ construct once outside loop when path is constant
+let path = StoragePath(identifier: "vault_main")!
+```
+
+**Individual counter increments**
+```cadence
+// ❌ N transactions of 5 CU each
+for _ in items {
+    self.head = self.head + 1
+}
+
+// ✅ single bulk update
+self.head = self.head + UInt64(items.length)
+```
+
+## Resource Inlining
+
+Resources with total encoded size ≤ 512 bytes are inlined in their parent — zero extra storage read. If a resource exceeds 512 bytes it spills to a separate slot, adding CU on every access.
+
+```
+Rough field sizes (encoded):
+  UInt64      8 bytes
+  UFix64      8 bytes
+  Address    20 bytes
+  String      variable (length prefix + content)
+  Bool        1 byte
+
+Check: sum(field_sizes) ≤ 512 bytes → inlined → no extra CU
+```
+
+## Composite Key Packing
+
+```cadence
+// ❌ String key: 85 bytes, hashed twice per write
+let key = fromAddr.toString().concat("->").concat(toAddr.toString())
+self.edges[key] = weight
+
+// ✅ packed UInt64: 8 bytes, same hash cost
+let key: UInt64 = (UInt64(fromId) << 32) | UInt64(toId)
+self.edges[key] = weight
+```
+
+Only works when both components fit in UInt32 (max value ~4.3 billion each).
+
+## Sweep Methodology for Measuring MAX_SAFE_N
+
+Run the transaction at increasing N values and record the fee from `FlowFees.FeesDeducted`:
+
+```
+N = [64, 128, 256, 512, 768, 1024, 1280, 1536]
+```
+
+1. Find the cliff where the tx fails — binary-search the exact limit at ±4 entries.
+2. Plot fee vs N: y-intercept = fixed overhead, slope = CU/entry.
+3. Set MAX_SAFE_N = highest passing N with ≥10% headroom below 9,999 CU.
+
+```
+RECOMMENDED_FEE_PER_ENTRY = (FEE_PER_TX / MAX_SAFE_N) × 1.10
+```
+
+## EVM CU Interaction
+
+Cross-VM calls consume CU on the Cadence side in addition to EVM gas:
+
+| Call type | Cadence CU overhead | EVM gas |
+|-----------|---------------------|---------|
+| `EVM.dryCall` simple view | ~50–100 CU | consumed but not charged |
+| `EVM.dryCall` large array return | ~200–800 CU | scales with return data size |
+| `coa.call` state mutating | ~200–500 CU | charged separately in FLOW |
+
+Decode `EVM.Result.data` inline — passing a large `[UInt8]` as a function argument costs extra CU at the function boundary.

--- a/plugins/flow-dev/skills/flow-defi/references/protocol-architecture.md
+++ b/plugins/flow-dev/skills/flow-defi/references/protocol-architecture.md
@@ -122,3 +122,78 @@ access(all) fun getRandomSeed(blockHeight: UInt64): [UInt8] {
 **DeFi applications:** Fair lottery/raffle contracts, randomized NFT drops, prediction market resolution.
 
 > **See also:** `defi-primitives.md` for building blocks (lending models, AMM selection).
+
+---
+
+## Cross-VM Failure Modes
+
+Understanding what happens when the EVM component of an atomic transaction fails.
+
+### Atomicity Guarantee
+
+A Cadence transaction containing EVM calls is atomic at the Cadence level:
+- If the Cadence transaction panics, all state changes (Cadence + EVM) are reverted.
+- If an EVM call fails, the EVM state change is reverted, but **Cadence execution continues** unless you explicitly check the result and panic.
+
+```cadence
+let result = coa.call(to: evmAddr, data: calldata, gasLimit: 100000, value: EVM.Balance(attoflow: 0))
+
+// result.status is NOT automatically checked — you must handle failure explicitly
+if result.status != EVM.Status.successful {
+    panic("EVM call failed: ".concat(result.errorCode.toString()))
+}
+```
+
+Failing to check `result.status` means the Cadence transaction succeeds and its state changes persist even when the EVM call silently failed.
+
+### EVM.Status Values
+
+| Status | Meaning |
+|--------|---------|
+| `EVM.Status.successful` | EVM call executed and committed |
+| `EVM.Status.failed` | EVM call reverted — EVM state unchanged |
+| `EVM.Status.invalid` | Malformed call (bad calldata, insufficient gas) |
+
+### Gas Exhaustion
+
+If `gasLimit` is too low for the EVM call, the call fails with `EVM.Status.failed` and the gas is consumed. The Cadence transaction continues unless you panic on failure.
+
+Conservative gas defaults:
+- Simple view call: `50_000`
+- Array read (N ≤ 1024): `3_000_000`
+- State-mutating call: `100_000`
+
+### Handling Partial Batch Failures
+
+When batching multiple EVM calls in one Cadence transaction, decide upfront whether partial success is acceptable:
+
+```cadence
+// All-or-nothing: panic on any failure
+for call in calls {
+    let result = coa.call(to: call.to, data: call.data, gasLimit: call.gas, value: EVM.Balance(attoflow: 0))
+    if result.status != EVM.Status.successful {
+        panic("batch aborted at call ".concat(call.label).concat(": ").concat(result.errorCode.toString()))
+    }
+}
+
+// Best-effort: log failures, continue
+var failedCalls: [String] = []
+for call in calls {
+    let result = coa.call(to: call.to, data: call.data, gasLimit: call.gas, value: EVM.Balance(attoflow: 0))
+    if result.status != EVM.Status.successful {
+        failedCalls.append(call.label)
+    }
+}
+```
+
+### CU Interaction with EVM Calls
+
+EVM calls consume Cadence CU in addition to EVM gas:
+
+| Call type | Cadence CU overhead |
+|-----------|---------------------|
+| `EVM.dryCall` simple view | ~50–100 CU |
+| `EVM.dryCall` large array return | ~200–800 CU |
+| `coa.call` state mutating | ~200–500 CU |
+
+Both EVM gas and Cadence CU must stay within budget. A transaction that stays under 9,999 CU but exceeds the EVM `gasLimit` will have the EVM call fail silently (unless you panic on `result.status`).

--- a/plugins/flow-dev/skills/flow-dev-setup/SKILL.md
+++ b/plugins/flow-dev/skills/flow-dev-setup/SKILL.md
@@ -31,6 +31,7 @@ Install and configure the tools needed for Flow blockchain development. Each ref
 | Start and configure the Flow Emulator (ports, persistence, fork mode) | [emulator.md](references/emulator.md) |
 | Install Cadence VS Code extension for editor support | [vscode-extension.md](references/vscode-extension.md) |
 | Set up testing framework, run tests, coverage, fork testing | [testing.md](references/testing.md) |
+| CDC vs Go/overflow decision tree, adversarial test categories, coverage interpretation | [testing-patterns.md](references/testing-patterns.md) |
 | Set up dev wallet for local frontend auth testing | [dev-wallet.md](references/dev-wallet.md) |
 | Install FCL or React SDK for frontend integration | [frontend-sdk.md](references/frontend-sdk.md) |
 | Set up Cadence MCP server for AI-assisted development | [cadence-mcp.md](references/cadence-mcp.md) |

--- a/plugins/flow-dev/skills/flow-dev-setup/references/testing-patterns.md
+++ b/plugins/flow-dev/skills/flow-dev-setup/references/testing-patterns.md
@@ -1,0 +1,140 @@
+# Flow Testing Patterns
+
+Complements [testing.md](testing.md) with framework selection, adversarial test design, and coverage interpretation.
+
+## CDC Native vs Go/Overflow Decision Tree
+
+```
+Requires FlowToken transfers, FlowTransactionScheduler,
+RandomConsumer, or any system contract?
+  YES → Go/overflow (emulator with real system contracts)
+  NO  → CDC native (flow test --cover, pure Cadence sandbox)
+
+Requires 2+ accounts signing the same transaction?
+  YES → Go/overflow
+  NO  → CDC native (multi-account sequential txs are supported)
+
+Verifying scheduled/delayed execution or commit-reveal?
+  YES → Go/overflow only
+```
+
+## Adversarial Test Categories
+
+Every contract needs tests in all applicable categories before deploy:
+
+| Category | What to test |
+|----------|-------------|
+| Privilege escalation | Non-admin calling admin functions; user calling artist-only functions |
+| Resource manipulation | Deposit+withdraw cycles; double-spend; force-unwrap paths |
+| Arithmetic | UFix64 subtraction below zero; overflow on counters; 100% royalty cut |
+| Storage attacks | Overwriting another account's path; claiming capabilities not addressed to caller |
+| Loyalty/points farming | Repeated deposit-withdraw cycles inflating score beyond expected ceiling |
+| Capability abuse | Using capability after revocation; copying from `access(all)` fields |
+| Scheduling attacks | Calling scheduled transaction handlers directly without scheduler entitlement |
+
+## CDC Native — Adversarial Pattern
+
+```cadence
+import Test
+import "MyContract"
+
+access(all) fun setup() {
+    Test.expect(
+        Test.deployContract(name: "MyContract", path: "../contracts/MyContract.cdc", arguments: []),
+        Test.beNil()
+    )
+}
+
+access(all) fun testUnauthorizedWithdrawFails() {
+    let attacker = Test.createAccount()
+    let result = Test.executeTransaction(
+        code: "../transactions/Withdraw.cdc",
+        args: [],
+        signers: [attacker]
+    )
+    Test.expect(result, Test.beFailed())
+}
+
+access(all) fun testLoyaltyFarmingBlocked() {
+    let attacker = Test.createAccount()
+    // deposit multiple times, withdraw once
+    // ...
+    let points = Test.executeScript(
+        code: "import \"MyContract\"; access(all) fun main(addr: Address): UFix64 { return MyContract.getPoints(addr) }",
+        args: [Test.Matcher.any()]
+    ).returnValue! as! UFix64
+    Test.assert(points <= 10.0, message: "points should not exceed ceiling after farming attempt")
+}
+```
+
+## Go/Overflow — Integration Test Pattern
+
+Use [overflow](https://github.com/bjartek/overflow) for tests that need system contracts.
+
+```go
+import (
+    "testing"
+    "github.com/bjartek/overflow/v2"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestEscrowReleasesToSeller(t *testing.T) {
+    o, _ := overflow.New(overflow.WithNetwork("testing"))
+
+    o.Tx("transactions/fund_account.cdc").
+        SignProposeAndPayAs("service").
+        Args(o.Arguments().Account("seller").UFix64(100.0)).
+        RunPanic(t)
+
+    o.Tx("transactions/create_escrow.cdc").
+        SignProposeAndPayAs("buyer").
+        Args(o.Arguments().UFix64("10.0").Account("seller")).
+        RunPanic(t)
+
+    sellerBalance := o.ScriptFromFile("scripts/get_flow_balance.cdc").
+        Args(o.Arguments().Account("seller")).
+        RunReturnsInterface(t)
+
+    assert.Greater(t, sellerBalance.(float64), 100.0)
+}
+
+// Test expected to fail — use RunE
+func TestUnauthorizedMintFails(t *testing.T) {
+    o, _ := overflow.New(overflow.WithNetwork("testing"))
+    err := o.Tx("transactions/MintNFT.cdc").
+        SignProposeAndPayAs("attacker").
+        RunE()
+    assert.Error(t, err)
+}
+```
+
+## Coverage Interpretation
+
+`flow test --cover` output:
+
+| Symbol | Meaning |
+|--------|---------|
+| ✅ covered | Function called at least once |
+| ❌ uncovered | Function never called — write a test |
+| ⚠️ partial | Called but some branches (if/else, pre/post) not exercised |
+
+**Known limitation:** `flow test --cover` cannot instrument contracts that import system contracts (`FlowToken`, `FlowTransactionScheduler`, `RandomConsumer`). For these, coverage comes only from Go/overflow tests. Document this gap explicitly — do not attempt workarounds.
+
+## Output Format for Test Results
+
+```
+SUITE: <name>
+FRAMEWORK: CDC native | Go/overflow
+TESTS: <N total> — <N positive> positive, <N adversarial> adversarial
+COVERAGE: <N>% — uncovered: <list of function names>
+KNOWN GAPS: <functions not coverable due to system contract dependency>
+
+RESULTS:
+  ✅ <N> passed
+  ❌ <N> failed — <function name>: <reason>
+
+For each adversarial test:
+  EXPLOIT TESTED: <finding ID or description>
+  EXPECTED: reverts | state unchanged | event not emitted
+  RESULT: ✅ blocked | ❌ EXPLOITABLE
+```

--- a/plugins/flow-dev/skills/flow-dev-setup/references/testing-patterns.md
+++ b/plugins/flow-dev/skills/flow-dev-setup/references/testing-patterns.md
@@ -32,6 +32,19 @@ Every contract needs tests in all applicable categories before deploy:
 | Capability abuse | Using capability after revocation; copying from `access(all)` fields |
 | Scheduling attacks | Calling scheduled transaction handlers directly without scheduler entitlement |
 
+## Cadence Test File Hard Constraints
+
+These constraints apply to every `_test.cdc` file. Violating any of them causes tests to be silently dropped from `flow test` output without a useful error:
+
+| Constraint | Wrong | Correct |
+|---|---|---|
+| No `Test.newBlockchain()` | `let bc = Test.newBlockchain()` | Use `Test.createAccount()` directly |
+| No triple-quoted strings | `` let code = """...""" `` | `Test.readFile("../transactions/X.cdc")` |
+| No `Test.Account` type annotation | `var acct: Test.Account!` | `let acct = Test.createAccount()` |
+| Inline scripts must be one line | multi-line string literal | single short expression or `Test.readFile()` |
+
+**Count check:** After writing the file, run `flow test`. Count the test names in output. Count `access(all) fun test*()` in the file. They must match. If not — the file has a silent error; fix before proceeding.
+
 ## CDC Native — Adversarial Pattern
 
 ```cadence

--- a/plugins/flow-dev/skills/flow-dev-setup/references/testing.md
+++ b/plugins/flow-dev/skills/flow-dev-setup/references/testing.md
@@ -125,6 +125,59 @@ You can also use a pragma in test files:
 #test_fork(network: "mainnet", height: nil)
 ```
 
+## Common Mistakes That Silently Drop Tests
+
+These errors cause the framework to skip tests without a clear error message — the test count in output will be less than the number of `test*` functions in the file.
+
+### ❌ `Test.newBlockchain()` — does not exist
+```cadence
+// WRONG — API does not exist; compile fails silently
+access(all) let blockchain = Test.newBlockchain()
+```
+```cadence
+// CORRECT — use Test functions directly at module level
+access(all) let account = Test.createAccount()
+```
+
+### ❌ Multi-line inline Cadence strings (heredocs)
+Cadence does not support triple-quoted strings. Embedding long Cadence code inline as a string literal will fail to parse.
+```cadence
+// WRONG — Cadence has no triple-quote syntax
+let code = """
+    access(all) fun main(): Int { return 1 }
+"""
+```
+```cadence
+// CORRECT — use Test.readFile() for transactions and scripts
+let result = Test.executeTransaction(
+    code: Test.readFile("../transactions/Mint.cdc"),
+    args: [],
+    signers: [signer]
+)
+```
+If you must inline a script, keep it to a single short line:
+```cadence
+let result = Test.executeScript(code: "access(all) fun main(): Int { return 1 }", args: [])
+```
+
+### ❌ Wrong module-level variable type for accounts
+`Test.createAccount()` returns an opaque value — store the `.address` if you only need the address later:
+```cadence
+// CORRECT — store full account for use as signer
+access(all) let owner = Test.createAccount()
+
+// CORRECT — store only address if you don't need to sign
+access(all) let ownerAddr: Address = Test.createAccount().address
+```
+
+### Verification rule — count must match
+After writing N test functions, `flow test` output must list exactly N test names.
+If you wrote 8 tests and only 3 appear, the file has a parse or check error — run:
+```bash
+flow test --name testSpecificName   # isolate which test fails to load
+```
+Do not report a test suite as complete until the reported count equals the written count.
+
 ## Documentation
 
 - Official docs: https://developers.flow.com/tools/flow-cli/tests

--- a/plugins/flow-dev/skills/flow-project-setup/SKILL.md
+++ b/plugins/flow-dev/skills/flow-project-setup/SKILL.md
@@ -25,6 +25,7 @@ flow test              # Run tests
 |------|-----------|
 | flow.json, FCL config, contract addresses, dependencies, CLI commands | [configuration.md](references/configuration.md) |
 | Dev workflow, deployment, debugging, gas optimization, testnet validation | [workflow.md](references/workflow.md) |
+| Allowed/forbidden upgrades, new-name strategy, rollback, multi-contract deploy | [upgrade-strategies.md](references/upgrade-strategies.md) |
 
 ## Companion Skills
 

--- a/plugins/flow-dev/skills/flow-project-setup/references/upgrade-strategies.md
+++ b/plugins/flow-dev/skills/flow-project-setup/references/upgrade-strategies.md
@@ -1,0 +1,112 @@
+# Contract Upgrade Strategies
+
+## What Cadence Allows and Forbids
+
+Cadence enforces upgrade safety at the protocol level. The CLI will reject invalid upgrades.
+
+| Change | Allowed? |
+|--------|----------|
+| Add a new function | ✅ |
+| Change function body (same signature) | ✅ |
+| Add a new field to a struct (with default) | ✅ |
+| Remove a field from a struct or resource | ❌ |
+| Change a field type | ❌ |
+| Remove a public function | ❌ |
+| Change a function signature | ❌ |
+| Add a field to a resource | ❌ (resource storage incompatible) |
+
+Any forbidden change requires deploying under a **new contract name** — existing storage under the old name is abandoned.
+
+## Upgrade Checklist
+
+Before running `flow project deploy` on an existing contract:
+
+```
+[ ] flow project deploy --update --dry-run  (check for rejection before submitting)
+[ ] All changed function signatures are backward-compatible
+[ ] No struct/resource fields removed or retyped
+[ ] New fields on structs have default values in init()
+[ ] Tests pass against the upgraded contract on emulator
+[ ] Testnet deploy verified before mainnet
+```
+
+## New Contract Name Strategy
+
+When a resource schema change is unavoidable:
+
+1. Deploy `MyContractV2` alongside `MyContract` (do not remove the old one).
+2. Write a migration transaction that reads resources from the old path, transforms them, and stores under the new path.
+3. Give users a migration window — document the cutoff block height.
+4. After migration window closes, stop referencing `MyContract` in new transactions.
+
+```cadence
+transaction() {
+    prepare(signer: auth(LoadValue, SaveValue) &Account) {
+        // Load old resource (removes it from storage)
+        let old <- signer.storage.load<@MyContract.OldResource>(from: /storage/myResource)
+            ?? panic("nothing to migrate")
+
+        // Transform and save under new contract type
+        let new <- MyContractV2.wrap(legacy: <- old)
+        signer.storage.save(<-new, to: /storage/myResourceV2)
+    }
+}
+```
+
+## Testnet Validation Before Mainnet
+
+Always deploy to testnet first and run the full post-deploy checklist:
+
+```bash
+flow project deploy --network testnet
+
+# Smoke test: read initialized state
+flow scripts execute cadence/scripts/GetState.cdc --network testnet
+
+# Write test: confirm a transaction seals
+flow transactions send cadence/transactions/Ping.cdc --network testnet --signer testnet-account
+
+# Verify round-trip
+flow scripts execute cadence/scripts/GetState.cdc --network testnet
+```
+
+Only promote to mainnet after all three steps pass.
+
+## Rollback
+
+Cadence has no rollback. Once a contract is deployed to mainnet it cannot be removed, only updated (within the allowed changes above).
+
+Mitigation strategies:
+- **Admin pause function**: include an `access(Admin) fun pause()` that gates all state-mutating functions behind a boolean. Deploy with `paused = false`. If a bug is found, call pause to stop damage while a fix is prepared.
+- **Emergency contact**: document an on-call address that holds the admin capability.
+
+```cadence
+access(all) resource Admin {
+    access(all) fun pause() {
+        MyContract.paused = true
+    }
+    access(all) fun unpause() {
+        MyContract.paused = false
+    }
+}
+
+access(all) fun assertNotPaused() {
+    assert(!MyContract.paused, message: "contract is paused")
+}
+```
+
+Add `assertNotPaused()` as the first line of every state-mutating function.
+
+## Multi-Contract Coordinated Deploy
+
+When deploying multiple interdependent contracts, order matters — dependencies must be deployed first.
+
+```json
+"deployments": {
+  "testnet": {
+    "testnet-account": ["FungibleToken", "FlowToken", "MyToken", "MyDEX"]
+  }
+}
+```
+
+`flow project deploy` resolves this order automatically from the import graph. If a contract fails mid-deploy, the remaining contracts are not deployed — fix the error and re-run. Partial deploys do not need manual cleanup because the failed contract simply isn't on-chain yet.


### PR DESCRIPTION
## Summary

Adds reference content to five existing skills, based on hitting real walls
with Flow/Cadence:

- **cadence-lang**: new `cu-optimization.md` (CU cost per operation, dict
  vs array trade-offs, resource inlining, composite key packing, sweep
  methodology for MAX_SAFE_N, EVM CU interaction); 2 new entries in
  `anti-patterns.md` (`access(account)` in multi-contract accounts;
  `Burner.burn()` on external token vaults)
- **cadence-audit**: new "Cross-VM and DeFi Advanced Checks" section in
  `audit-checklist.md` covering 11 vuln classes from real exploits (Cetus
  fixed-point overflow, bridge precision loss, the Dec 2025 init-arg
  smuggling, `access(account)` co-deploy escalation, use-after-free)
- **flow-defi**: new "Cross-VM Failure Modes" section in
  `protocol-architecture.md` (atomicity guarantees, EVM.Status values,
  gas exhaustion, partial batch failures, CU interaction)
- **flow-dev-setup**: new `testing-patterns.md` (decision tree, adversarial
  categories, coverage interpretation) plus a "Common Mistakes That
  Silently Drop Tests" section in `testing.md`. Caught a case where 11
  tests disappeared from the runner because of a heredoc string.
- **flow-project-setup**: new `upgrade-strategies.md` (what Cadence
  allows/forbids, new-contract-name strategy, rollback, multi-contract
  coordinated deploy)