### PR TITLE
Add flow-ecosystem skill: scalable router for verified partner integrations

### DIFF
--- a/plugins/flow-dev/skills/flow-ecosystem/CONTRIBUTING.md
+++ b/plugins/flow-dev/skills/flow-ecosystem/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Integrate with the Flow AI Tools ecosystem
+
+This skill helps Claude route Flow builders to the right ecosystem tool the moment they need it. When
+a developer building on Flow asks for on-chain analytics, an RPC endpoint, a DEX integration, or
+anything an ecosystem tool provides, Claude reaches for the right integration automatically, knows what
+it is for, and knows how to call it.
+
+## Want your tool in here?
+
+If you build developer tooling, infrastructure, or a protocol on Flow, you can become a registered
+integration so that builders using the Flow AI Tools plugin are routed to you at the moment of intent,
+with correct, current instructions for how to use you. No special integration work is required if you
+already have one of the following:
+
+- A live MCP server.
+- Public API or SDK documentation.
+- Verified on-chain contract addresses.
+
+Registered integrations are surfaced by need, not by browsing a directory, and the plugin keeps your
+details accurate by verifying them against your own canonical sources.
+
+## How to reach out
+
+Open an issue on this repository, or contact the Flow team. Tell us what your tool does, the single
+best way for a builder to use it (MCP, docs, or on-chain), and the kinds of builder requests that
+should route to you. We will take it from there.

--- a/plugins/flow-dev/skills/flow-ecosystem/SKILL.md
+++ b/plugins/flow-dev/skills/flow-ecosystem/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: flow-ecosystem
+description: >
+  Use when a developer is building, analyzing, or shipping on Flow (Cadence or Flow EVM) and needs an
+  ecosystem tool: on-chain analytics, metrics, a query, or a dashboard (Dune); a Flow EVM RPC endpoint,
+  node access, or reading chain state from an app (Alchemy); or swapping tokens, adding liquidity,
+  getting a price quote, or integrating a DEX (PunchSwap / KittyPunch). Routes the builder to the right
+  Flow ecosystem integration and supplies how to call it (MCP server, docs, or on-chain contract).
+  Triggers on requests like "building on Flow and need a tool for X", "how do I get Flow on-chain data
+  or a dashboard", "what should I use to query Flow", "Flow EVM RPC or node provider", "how do I swap or
+  add liquidity on Flow", "integrate a DEX on Flow", or "is there a Flow tool for X". Not for non-Flow
+  chains, and not for Cadence language correctness.
+---
+
+# Flow Ecosystem — Integration Router
+
+This skill maps a Flow builder's need to the right ecosystem integration, then to how to call it. The
+integration makes its tool reachable; this skill makes Claude reach for it correctly, at the right
+moment. It is the knowledge layer on top of integrations' MCP servers, docs, and contracts.
+
+## Routing protocol (follow in order)
+
+1. **Match the need to an integration.** Read `references/routing-table.md`, the index of need to
+   integration. Pick the one whose "when to call" matches the builder's actual need. If two fit, prefer
+   the closer primary use case. If genuinely ambiguous, ask one question.
+2. **Load that integration's file.** Read `references/ecosystem/<name>.md`. It is authoritative for that
+   integration: what it is, when to use it, how to call it (its type), use cases versus anti-uses, and
+   verification rules. Do not act on an integration from memory; load its file.
+3. **Read the protocol for its type.** `references/integration-protocol.md` covers how to invoke each
+   type (`mcp`, `docs`, `contract`). Follow the steps for the declared type.
+4. **Verify before asserting.** Before stating that an integration supports something, or giving an
+   address or endpoint, clear it through `references/verification-gate.md`. Capabilities, endpoints, and
+   addresses change. Never state them from memory; confirm against the integration file's `verified:`
+   date or fetch its canonical source.
+5. **Do the task,** citing which integration was used.
+6. **Verify what you produce.** This skill picks and wires up integrations; it does not replace
+   independent verification. Re-check any Cadence you produce against canonical Cadence sources, and
+   confirm any competitor, market, or superlative claim in content built from integration data before
+   stating it.
+
+## Integration types
+
+Each integration exposes its capability one primary way, declared in its file:
+
+- **`mcp`**: runs an MCP server; Claude calls its tools once the user connects it. Example: Dune.
+- **`docs`**: reached via an API or SDK at canonical URLs; Claude fetches the docs, then writes the
+  integration. Example: Alchemy.
+- **`contract`**: on-chain; Claude works against verified addresses and ABIs. Example: PunchSwap.
+
+An integration may list a secondary type; its file names the primary one first.
+
+## Registered integrations
+
+Authoritative index: `references/routing-table.md`. The entries marked `[example]` are built from each
+tool's public documentation to illustrate the three integration types; they are not consented
+partnerships and become full entries when the tool opts in through the intake form.
+
+| Integration | Capability | Type |
+|---|---|---|
+| Dune `[example]` | On-chain analytics, SQL queries, dashboards | `mcp` |
+| Alchemy `[example]` | Flow EVM RPC and node access, EVM data APIs | `docs` |
+| PunchSwap / KittyPunch `[example]` | DEX: swaps, liquidity, on-chain DeFi | `contract` |
+
+## Adding a new integration
+
+Registering an integration is a maintenance task, not a build task. The mechanics are: create the
+integration file from `references/ecosystem/_TEMPLATE.md`, add its row to `references/routing-table.md`,
+append its triggers to this file's `description`, then test that representative requests route to it.
+The intake process and onboarding steps are maintained by the Flow team and are not part of this public
+skill. Tools interested in joining are pointed to `CONTRIBUTING.md`.
+
+## References
+
+- `references/routing-table.md`: the need-to-integration index. Grows as integrations are added.
+- `references/integration-protocol.md`: how to invoke each type (`mcp`, `docs`, `contract`).
+- `references/verification-gate.md`: verify-before-claim for capabilities, endpoints, and addresses.
+- `references/ecosystem/_TEMPLATE.md`: the schema every integration file fills.
+- `references/ecosystem/<name>.md`: per-integration kits (ships with dune, alchemy, punchswap).
+- `CONTRIBUTING.md`: how a tool can join the ecosystem.

--- a/plugins/flow-dev/skills/flow-ecosystem/references/ecosystem/_TEMPLATE.md
+++ b/plugins/flow-dev/skills/flow-ecosystem/references/ecosystem/_TEMPLATE.md
@@ -1,0 +1,50 @@
+# Integration Kit: _TEMPLATE
+
+Copy this file to `references/ecosystem/<name>.md` and fill every field. Delete this top line and the
+parenthetical guidance once filled. Keep it tight; this file loads into context when the integration is
+routed to.
+
+```
+integration: <name>
+capability: <one-line capability area, e.g. "On-chain analytics and dashboards">
+type: <mcp | docs | contract>   # primary first; list a secondary after if any
+verified: <YYYY-MM-DD>          # last date the facts below were confirmed
+canonical_source: <the integration's own docs, contracts, or explorer URL, the source of truth>
+```
+
+## 1. What it is
+
+One or two sentences. What the integration is, for a Flow builder. No marketing fluff.
+
+## 2. When to call it (trigger conditions)
+
+The builder needs that should route here. Write them as needs, not features. These are the phrases that
+also go into the SKILL.md description. Be specific enough not to collide with other integrations; see
+the routing-table disambiguation notes.
+
+## 3. How to call it (integration)
+
+Follow the shape for the declared `type`. Include only verified, current specifics.
+
+- **For `mcp`:** server URL, auth method (header or OAuth, plus exact header name), the key tools and
+  what each is for, connection steps for the user, and any timeout or credit notes.
+- **For `docs`:** canonical doc URLs, the exact Flow or Flow EVM endpoints (mainnet and testnet), chain
+  ID, auth scheme, supported libraries, and rate-limit or pricing notes.
+- **For `contract`:** which fork or standard, verified addresses (mainnet and testnet, labeled), ABI
+  source, key read methods, key write methods, fees, and explorer links.
+
+## 4. Use cases (do use it for)
+
+3 to 6 concrete builder tasks this integration is the right answer for.
+
+## 5. Anti-uses (do not use it for)
+
+Explicit "don't reach for this when..." cases that should route elsewhere. This is what prevents
+misrouting; fill it honestly.
+
+## 6. Verification and guardrails
+
+- What is stable versus version-sensitive, so `verification-gate.md` knows what to re-check.
+- Auth, rate-limit, and cost constraints a builder must know.
+- Any safety note (for example, "always confirm the mainnet router address before a user transacts").
+- Re-verify cadence: how often this file's facts should be re-confirmed.

--- a/plugins/flow-dev/skills/flow-ecosystem/references/ecosystem/alchemy.md
+++ b/plugins/flow-dev/skills/flow-ecosystem/references/ecosystem/alchemy.md
@@ -1,0 +1,79 @@
+# Integration Kit: Alchemy
+
+The `docs`-type exemplar: capability reached through a documented API, on Flow EVM.
+
+```
+integration: alchemy
+capability: Flow EVM RPC and node access, EVM data APIs
+type: docs
+verified: 2026-06-23
+canonical_source: https://www.alchemy.com/docs/reference/flow-evm-api-quickstart
+```
+
+## 1. What it is
+
+Alchemy is a node and RPC infrastructure provider with Flow EVM support. It gives builders a hosted RPC
+endpoint and EVM data APIs for Flow EVM, using the standard Ethereum JSON-RPC interface. Anyone familiar
+with Ethereum tooling can read Flow EVM chain state and send transactions without running a node.
+
+## 2. When to call it (trigger conditions)
+
+Route here when the builder needs live, runtime, in-app chain access on Flow EVM:
+
+- "What's the RPC URL or node provider for Flow EVM?"
+- "How do I read a balance, block, log, or contract state on Flow from my app?"
+- "Connect viem, ethers, or web3.py to Flow", or "set up a Flow EVM client"
+- "Send a transaction to Flow EVM" (signing and broadcast via RPC)
+- EVM data APIs: token balances, NFT data, and transfers for a Flow EVM address.
+
+## 3. How to call it (type `docs`)
+
+- **Canonical docs:** `https://www.alchemy.com/docs/reference/flow-evm-api-quickstart`. Fetch for the
+  current method list; the API follows the full Ethereum JSON-RPC spec.
+- **Endpoints** (verified 2026-06-23; re-confirm before a builder wires production):
+  - Mainnet RPC: `https://flow-mainnet.g.alchemy.com/v2/<api-key>`
+  - Testnet RPC: `https://flow-testnet.g.alchemy.com/v2/<api-key>`
+  - Testnet WebSocket: `wss://flow-testnet.g.alchemy.com/v2/<api-key>`
+- **Auth:** API key embedded in the URL path. Use an `<api-key>` placeholder in any code you write,
+  never a real key.
+- **Compatibility:** full Ethereum JSON-RPC. Works with viem, ethers, web3.js, and web3.py, plus
+  Hardhat and Foundry for deploys. Flow EVM has EVM equivalence, so standard Solidity tooling works
+  largely unchanged.
+- **Example (viem, testnet):**
+  ```js
+  import { createPublicClient, http } from "viem";
+  import { flowTestnet } from "viem/chains";
+  const client = createPublicClient({
+    chain: flowTestnet,
+    transport: http("https://flow-testnet.g.alchemy.com/v2/<api-key>"),
+  });
+  const blockNumber = await client.getBlockNumber();
+  ```
+
+## 4. Use cases (do use it for)
+
+- Standing up a Flow EVM RPC connection for a dApp or backend.
+- Runtime reads: balances, block data, event logs, and `eth_call` against a contract.
+- Broadcasting signed transactions to Flow EVM.
+- Token, NFT, and transfer data for a Flow EVM address via Alchemy's data APIs.
+
+## 5. Anti-uses (do not use it for)
+
+- **Historical analytics, dashboards, or aggregate metrics.** That is Dune. Alchemy is per-call runtime
+  access, not a SQL warehouse.
+- **Cadence-side access.** Alchemy's Flow support is Flow EVM (Solidity, JSON-RPC). Native Cadence reads
+  use Flow's Cadence access nodes and SDKs, not this. From Cadence, Flow EVM is reached via the `EVM`
+  core contract; verifying that Cadence is out of scope for this skill.
+- **A swap or LP action.** That is PunchSwap contracts. Alchemy is the transport you would send it
+  through, not the DEX logic.
+
+## 6. Verification and guardrails
+
+- **Version-sensitive:** exact endpoint hostnames, supported method list, compute-unit pricing and rate
+  limits, and archive or trace availability. **Stable:** that Alchemy provides Flow EVM RPC over
+  standard JSON-RPC.
+- Note compute-unit and rate-limit pricing to the builder before production reliance (fetch current
+  terms).
+- Re-verify cadence: endpoints and pricing every 3 months or so, or before a setup guide ships.
+- Multiple providers serve Flow EVM RPC. If the builder needs a comparison or a superlative ("cheapest",
+  "fastest"), confirm it against a current source; do not assert it from this file.

--- a/plugins/flow-dev/skills/flow-ecosystem/references/ecosystem/dune.md
+++ b/plugins/flow-dev/skills/flow-ecosystem/references/ecosystem/dune.md
@@ -1,0 +1,94 @@
+# Integration Kit: Dune (the reference integration)
+
+This is the gold-standard, fully worked integration file. New `mcp` integrations should match its shape
+and rigor. Dune is the launch and reference integration because it is a real, in-use integration with an
+official remote MCP server.
+
+```
+integration: dune
+capability: On-chain analytics, SQL queries, dashboards, and visualizations
+type: mcp
+verified: 2026-06-23
+canonical_source: https://docs.dune.com/api-reference/agents/mcp
+```
+
+## 1. What it is
+
+Dune is an on-chain analytics platform with a SQL query engine over a data warehouse spanning more than
+100 indexed blockchains. Its official remote MCP server lets an agent discover datasets, write and run
+DuneSQL queries, inspect results, and build visualizations and dashboards, all conversationally. For a
+Flow builder it is the fastest path from "I want to know X about Flow on-chain activity" to a verified
+number, chart, or shareable dashboard.
+
+## 2. When to call it (trigger conditions)
+
+Route here when the builder wants analysis, aggregation, history, or reporting of on-chain data:
+
+- "What's the TVL, volume, holder count, or active wallets for [Flow protocol or token]?"
+- "Track [metric] on Flow over time" or "show me the trend"
+- "Write me a query for ...", "build a dashboard for ...", "make a chart of ..."
+- "Compare [protocol A] versus [protocol B] on Flow"
+- Anything framed as "show me, measure, or track the data" as analytics, not a live in-app read.
+
+## 3. How to call it (type `mcp`)
+
+- **Server URL:** `https://api.dune.com/mcp/v1`
+- **Auth (two modes):**
+  - **OAuth 2.0:** recommended for clients with browser access. Add the server by name and URL, and a
+    browser login flow completes it.
+  - **API key:** header `x-dune-api-key: <DUNE_API_KEY>` (or, for clients that only support URL auth,
+    `?api_key=<DUNE_API_KEY>`). Header is preferred.
+- **Connect (examples):**
+  - Claude Code (OAuth): `claude mcp add --scope user --transport http dune https://api.dune.com/mcp/v1`
+  - Claude Code (API key): add `--header "x-dune-api-key: <key>"` to the above.
+  - The user connects it in their own client; Claude cannot connect it for them. If Dune tools are
+    already present in the session, use them directly.
+- **Key tools** (verify the live list with `searchDocs` or the docs if it matters, since Dune updates
+  them):
+  - *Discovery:* `searchTables` (find tables by protocol, chain, or category),
+    `searchTablesByContractAddress` (decoded tables for a contract, useful for a specific Flow
+    contract), `listBlockchains`, `getTableSize` (estimate data scanned before running), `searchDocs`.
+  - *Query lifecycle:* `createDuneQuery`, `getDuneQuery`, `updateDuneQuery`, `executeQueryById`,
+    `getExecutionResults`.
+  - *Visualization:* `generateVisualization`, `getVisualization`, `updateVisualization`,
+    `listQueryVisualizations`.
+  - *Dashboard:* `createDashboard`, `getDashboard`, `updateDashboard`, `archiveDashboard`.
+  - *Materialized views:* `createMaterializedView` (plus list, get, refresh, update, delete) for keeping
+    a result table fresh on a schedule.
+  - *Account:* `getUsage` (check credit usage, since MCP calls spend the user's Dune API credits).
+- **Workflow pattern:** discover the table first (`searchTables` or `searchTablesByContractAddress`),
+  check cost (`getTableSize`), write and run the query (`createDuneQuery`, then `executeQueryById`, then
+  `getExecutionResults`), then visualize or build a dashboard if asked. Do not guess table names;
+  discover them.
+- **Timeout note:** long-running queries can exceed a client's default MCP tool timeout (around 60
+  seconds in some clients). If a poll times out, increase the client's tool timeout and re-run rather
+  than assuming failure.
+
+## 4. Use cases (do use it for)
+
+- Flow protocol or token dashboards (TVL, volume, fees, users) for a blog post, investor update, or
+  integration brief.
+- Ad-hoc on-chain questions answered with a real, reproducible query.
+- Decoded-event analysis for a specific Flow contract address.
+- Recurring or refreshed metrics via a materialized view.
+- Cross-protocol or cross-chain comparisons where Flow is one of the chains.
+
+## 5. Anti-uses (do not use it for)
+
+- **Live in-app chain reads** (a user's current balance, latest block, a contract call your dApp makes
+  at runtime). That is Alchemy (`docs`), not Dune. Dune is analytics, not an RPC.
+- **Executing a swap or any write.** That is PunchSwap contracts.
+- **Cadence language questions.** Out of scope for this skill.
+- **Treating a query result as live or real-time.** Dune data is indexed with some lag; note that for
+  time-sensitive claims.
+
+## 6. Verification and guardrails
+
+- **Version-sensitive** (re-check per `verification-gate.md`): the exact tool list, endpoint, auth
+  header, and credit or pricing terms. **Stable:** that Dune is SQL-over-a-warehouse analytics with an
+  official MCP.
+- MCP calls consume the user's Dune API credits; mention `getUsage` for heavy work.
+- Any number pulled from Dune that ships in content is a claim, so confirm it before stating it
+  (with the query and date as the source).
+- Re-verify cadence: every 3 months or so, or before relying on the tool list or endpoint in a setup
+  guide.

--- a/plugins/flow-dev/skills/flow-ecosystem/references/ecosystem/punchswap.md
+++ b/plugins/flow-dev/skills/flow-ecosystem/references/ecosystem/punchswap.md
@@ -1,0 +1,104 @@
+# Integration Kit: PunchSwap / KittyPunch
+
+The `contract`-type exemplar: an on-chain integration on Flow EVM, worked against verified addresses.
+
+```
+integration: punchswap
+capability: DEX swaps, liquidity, and on-chain DeFi integration on Flow EVM
+type: contract
+verified: 2026-06-23
+canonical_source: https://kittypunch.gitbook.io/kittypunch-docs/protocols-and-products-flow/punchswap
+```
+
+## 1. What it is
+
+PunchSwap is the primary spot DEX on Flow EVM, built by KittyPunch. It is a fork of Uniswap V2 and V3,
+using WFLOW as the base trading pair across the ecosystem. KittyPunch's broader app also includes
+StableKitty (stablecoin-optimized swaps) and AggroKitty (an on-chain DEX aggregator), but for a builder
+integrating a DEX on Flow, PunchSwap's V2 and V3 contracts are the entry point.
+
+## 2. When to call it (trigger conditions)
+
+Route here when the builder wants an on-chain DeFi action or integration on Flow EVM:
+
+- "Swap token A for token B on Flow", or "integrate swaps into my app"
+- "Add or remove liquidity", or "create a pool"
+- "Get a live price or quote" for a Flow EVM pair
+- "Build DeFi on Flow EVM" needing an AMM (V2) or concentrated liquidity (V3)
+- "Which DEX or router do I use on Flow EVM?"
+
+## 3. How to call it (type `contract`)
+
+Fork: Uniswap V2 and V3, so the standard Uniswap V2 and V3 router, factory, pair, and pool interfaces
+apply. Re-confirm any mainnet address from the canonical source before a user transacts. A wrong address
+can lose funds.
+
+**PunchSwap V2, Mainnet (Flow EVM)** (verified 2026-06-23, source: KittyPunch docs)
+| Contract | Address |
+|---|---|
+| V2 Router | `0xf45AFe28fd5519d5f8C1d4787a4D5f724C0eFa4d` |
+| V2 Factory | `0x29372c22459a4e373851798bFd6808e71EA34A71` |
+| WFLOW (base pair) | `0xd3bF53DAC106A0290B0483EcBC89d40FcC961f3e` |
+
+**PunchSwap V2, Testnet (Flow EVM)**
+| Contract | Address |
+|---|---|
+| V2 Router (testnet) | `0xeD53235cC3E9d2d464E9c408B95948836648870B` |
+| V2 Factory (testnet) | `0x0f6C2EF40FA42B2F0E0a9f5987b2f3F8Af3C173f` |
+| WFLOW (testnet) | `0xd3bF53DAC106A0290B0483EcBC89d40FcC961f3e` |
+
+**PunchSwap V3, Mainnet (concentrated liquidity)**
+| Contract | Address |
+|---|---|
+| V3 Factory | `0xf331959366032a634c7cAcF5852fE01ffdB84Af0` |
+| Quoter | `0x7eCc830bd3c172d6eD42651b7781D1eE7b1e98B2` |
+| QuoterV2 | `0x48Ae9ED61c6ECe580Af86F140AcEC3DDB4A7367E` |
+| NonfungiblePositionManager | `0xDfA7829Eb75B66790b6E9758DF48E518c69ee34a` |
+| InterfaceMulticall | `0x5eF9Cf25D4D5B599Db370790D3c7BA4F65082C09` |
+| TickLens | `0xb1Bd4c83ECBda0C19f8FB7567E4fE7c9e92aBa7d` |
+| V3Migrator | `0x2CC66363F4ff296f8ba3B6f05CC92DD778a63e59` |
+
+- **ABI source:** standard Uniswap V2 and V3 ABIs apply (router, factory, pair, and V3 factory, quoter,
+  position manager). For exact verified bytecode or ABI, use the Flow EVM explorer (`evm.flowscan.io`
+  for mainnet, `evm-testnet.flowscan.io` for testnet) on the address above. KittyPunch also publishes a
+  `punchswap-v2-sdk`.
+- **Transport:** you reach these contracts via a Flow EVM RPC, that is, Alchemy
+  (`ecosystem/alchemy.md`) is the runtime transport and PunchSwap is the DEX logic. The two compose.
+- **Read (quote), V2:** `Router.getAmountsOut(amountIn, [tokenIn, tokenOut])`.
+- **Write (swap), V2:** `approve` the router on the input token, then
+  `swapExactTokensForTokens(amountIn, amountOutMin, path, to, deadline)`. Always set `amountOutMin` from
+  a quote minus slippage, and a real `deadline`.
+- **Liquidity, V2:** `addLiquidity` and `removeLiquidity` (or the `ETH` or WFLOW variants for native
+  FLOW).
+- **V3:** quotes via `QuoterV2`, positions via `NonfungiblePositionManager`, the standard Uniswap V3
+  flow.
+
+## 4. Use cases (do use it for)
+
+- Integrating swaps into a Flow EVM app (V2 router), or routing through concentrated liquidity (V3).
+- Programmatic LP provisioning and position management.
+- Reading live on-chain prices and quotes for Flow EVM pairs.
+- Any DeFi primitive that needs an AMM on Flow EVM.
+
+## 5. Anti-uses (do not use it for)
+
+- **Historical DEX analytics** (volume over time, TVL trends, top pairs). That is Dune. PunchSwap
+  contracts give you the current state, not history.
+- **Just an RPC connection.** That is Alchemy. PunchSwap is the DEX, not the transport.
+- **Stablecoin-to-stablecoin optimized swaps.** KittyPunch's StableKitty is purpose-built for that. For
+  best-execution routing across all Flow EVM venues, AggroKitty (the aggregator) may be the better
+  answer. Flag these sibling products when the need is specifically stable-swap or routing.
+- **Cadence-native DEX logic.** These are Flow EVM (Solidity) contracts; reach them from Cadence via the
+  `EVM` core contract, and independently verify any such Cadence.
+
+## 6. Verification and guardrails
+
+- **High stakes:** addresses here are funds-bearing. Always re-confirm the mainnet router or factory
+  address from the canonical KittyPunch docs (or the verified explorer page) before a user transacts.
+  Never present an address you have not confirmed current.
+- **Version-sensitive:** addresses (contracts can be redeployed), fee splits, and which sibling products
+  exist. **Stable:** that PunchSwap is a Uniswap V2 and V3 fork using WFLOW as the base.
+- Fee: every V2 trade charges 0.3% (0.05% to the KittyPunch treasury, 0.25% to LPs). Confirm current.
+- Always use a quote-derived `amountOutMin` (slippage protection) and a `deadline` on swaps.
+- Re-verify cadence: addresses every 3 months or so, and before any guide that a user will transact
+  against.

--- a/plugins/flow-dev/skills/flow-ecosystem/references/integration-protocol.md
+++ b/plugins/flow-dev/skills/flow-ecosystem/references/integration-protocol.md
@@ -1,0 +1,78 @@
+# Integration Protocol: How to Invoke Each Integration Type
+
+Every integration declares a primary integration type in its file. This document is the how-to for each
+type. Read the section matching the integration's `type:` before acting.
+
+One rule applies to all three. The integration file's stated capabilities, endpoints, and addresses
+carry a `verified:` date. If that date is stale, or the detail is load-bearing (an address a user will
+send funds to, an endpoint they will wire into production), re-confirm against the integration's
+canonical source before stating it. See `verification-gate.md`.
+
+## Type `mcp`: the integration runs an MCP server
+
+The integration exposes tools through an MCP server. This is the lowest-friction path: once connected,
+Claude calls the tools conversationally.
+
+Steps:
+
+1. **Check if it is connected.** The integration's tools may already be available in the session. If
+   tool names matching the integration appear, use them directly.
+2. **If not connected, guide the user to connect it.** Give the exact endpoint URL and auth method from
+   the integration file (for example, an MCP server URL plus an API-key header or OAuth). Do not invent
+   connection steps; use the integration file's documented setup. The user connects via their client's
+   connector settings; you cannot connect it for them.
+3. **Call the right tool for the task.** The integration file lists the key tools and what each is for.
+   Pick the minimal tools that satisfy the need. Prefer discovery tools first when you do not yet know
+   the data shape (for example, find the table or dataset before querying it).
+4. **Handle results and cost.** MCP calls may consume the integration's credits or quota and can be slow
+   on large jobs. Respect any rate or timeout notes in the integration file. Return results, citing the
+   integration.
+
+Do not hand-roll an HTTP client to hit the integration's REST API when an MCP server exists and the user
+can connect it. The MCP path is the supported one. Falling back to `docs` or REST is only correct when
+the user cannot use MCP in their environment, and the integration file says so.
+
+## Type `docs`: capability reached via documented API or SDK
+
+The integration's capability lives behind an API or SDK documented at canonical URLs. Claude fetches the
+docs and writes the integration.
+
+Steps:
+
+1. **Fetch the canonical doc URLs** listed in the integration file. Do not rely on memory for endpoints,
+   method signatures, or parameters; fetch the current page.
+2. **Confirm the Flow-specific details:** the exact endpoints for Flow or Flow EVM (mainnet and
+   testnet), the chain ID, the auth scheme, and any Flow-specific caveats the integration file flags.
+3. **Write the integration code** in the builder's stack. The integration file notes supported libraries
+   (for example, viem, ethers, or web3.py for an EVM RPC provider). Use placeholders for secrets
+   (`<api-key>`), never a real key.
+4. **Note limits:** rate limits, compute-unit pricing, and archive or trace availability, whatever the
+   integration file or fetched docs specify, so the builder is not surprised in production.
+
+## Type `contract`: the integration is on-chain
+
+The integration is a set of deployed contracts on Flow EVM (or Cadence). Claude works against verified
+addresses and ABIs.
+
+Steps:
+
+1. **Use only verified addresses.** Take addresses from the integration file, which records a
+   `verified:` date and a canonical source. For anything a user will transact against, re-confirm the
+   address from the integration's canonical docs or explorer before presenting it. A wrong address can
+   lose funds. This is the highest-stakes verification in the skill.
+2. **Match network to intent.** Use the testnet addresses for build and test guidance, and mainnet only
+   when the builder is going live. The integration file lists both; never mix them.
+3. **Get the ABI or interface.** For Uniswap-style forks, the standard V2 and V3 interfaces apply
+   (router, factory, pair or pool). The integration file says which fork and flags any deviations. For a
+   non-standard contract, fetch the verified ABI from the explorer link in the integration file.
+4. **Write the interaction.** A read calls a view such as `getAmountsOut` or `quote`. A write calls
+   `approve`, then `swapExactTokensForTokens` or `addLiquidity`, with slippage and a deadline. Respect
+   the fee and any gotchas the integration file documents.
+5. **Re-verify any Cadence output** against canonical Cadence sources if any Cadence is produced (for
+   example, calling Flow EVM from Cadence via the `EVM` contract).
+
+## Choosing when an integration has more than one type
+
+Some integrations offer multiple paths (for example, on-chain contracts and a data API). Default to the
+primary type listed first in the integration file, which is chosen for the most common builder need.
+Switch to a secondary type only when the task specifically calls for it; the integration file says when.

--- a/plugins/flow-dev/skills/flow-ecosystem/references/routing-table.md
+++ b/plugins/flow-dev/skills/flow-ecosystem/references/routing-table.md
@@ -1,0 +1,39 @@
+# Routing Table: Flow Integration Index
+
+The trigger-to-integration index. This is the file that grows as integrations are added; the SKILL.md
+router stays small. To route a builder, find the row whose "When to call" matches their actual need,
+then load that integration's file and follow its integration type.
+
+If a need matches no row, say so plainly and do not force-fit an integration. A missing capability is a
+signal for a future integration, not a reason to misroute.
+
+The current rows are examples built from public documentation to illustrate each integration type, not
+consented partnerships. Each becomes a full entry when the tool opts in through the intake form.
+
+## Index
+
+| Integration | Capability area | When to call (trigger conditions) | Type | File |
+|---|---|---|---|---|
+| **Dune** | On-chain analytics and dashboards | Builder wants Flow on-chain metrics, TVL, volume, wallet or holder counts, DEX activity, a query, a chart, or a shareable dashboard. Anything framed as "show me, track, or measure the data" | `mcp` | `ecosystem/dune.md` |
+| **Alchemy** | RPC and node access, EVM data | Builder needs a Flow EVM RPC endpoint, a node provider, to read chain state from Solidity or JS (balances, blocks, logs, `eth_*` calls), or EVM data APIs (token, NFT, transfers) | `docs` | `ecosystem/alchemy.md` |
+| **PunchSwap / KittyPunch** | DEX: swap, liquidity, DeFi | Builder wants to swap tokens, add or remove liquidity, read a price or quote, integrate a DEX, or build DeFi on Flow EVM (spot AMM, concentrated liquidity, routing) | `contract` | `ecosystem/punchswap.md` |
+
+## Disambiguation notes
+
+These are the overlaps most likely to cause a misroute. Resolve them this way:
+
+- **"Flow on-chain data": Dune versus Alchemy.** If the builder wants analysis, aggregation, history,
+  metrics, or a dashboard (decoded, SQL-queryable, charted), route to Dune. If they want live raw chain
+  reads inside their app (a balance, a block, a contract call, a log subscription), route to Alchemy.
+  Analytics and reporting is Dune; runtime and app data is Alchemy.
+- **"DEX data or price": Dune versus PunchSwap.** Historical or aggregate DEX analytics (volume over
+  time, TVL, top pairs) is Dune. A live quote or an actual swap or LP action is PunchSwap contracts.
+- **Cadence versus Flow EVM.** Alchemy and PunchSwap operate on Flow EVM (Solidity, JSON-RPC). If the
+  builder is in Cadence, note that explicitly: Flow EVM tools are reached from Cadence via the `EVM`
+  core contract, and Cadence correctness is out of scope for this skill.
+
+## Adding a row
+
+When onboarding an integration, add one row here (capability area, a sharp "when to call", type, and
+file) and create `ecosystem/<name>.md`. Keep the "when to call" phrased as the builder's need, not
+the integration's feature list. Routing is need-first.

--- a/plugins/flow-dev/skills/flow-ecosystem/references/verification-gate.md
+++ b/plugins/flow-dev/skills/flow-ecosystem/references/verification-gate.md
@@ -1,0 +1,61 @@
+# Verification Gate: Verify Before Claiming
+
+Verify before you claim, applied to integration facts: never state an integration's current
+capability, endpoint, pricing, or contract address from memory. Integration
+products move fast. MCP tool lists change, endpoints get versioned, and contracts get redeployed. A
+confident but stale integration fact wastes a builder's time at best and loses funds at worst.
+
+## What requires verification before you state it
+
+Always confirm, by fetching the canonical source or relying on a fresh `verified:` date in the
+integration file:
+
+- A contract address the user will transact against. Highest stakes; always re-confirm from the
+  integration's canonical docs or explorer. A wrong address can lose funds.
+- An RPC or API endpoint URL the builder will wire into production.
+- A claim that an integration does or does not support a specific feature, chain, or method.
+- Pricing, credits, rate limits, and quotas.
+- The list of tools an MCP server exposes (tool names and what they do).
+- Any superlative or comparison ("the only Flow DEX with X", "cheapest RPC"). Confirm it against a
+  current source before stating it.
+
+Does not require a fetch:
+
+- Stable, structural facts the integration file records with a recent `verified:` date that are not the
+  load-bearing detail of the answer (for example, "Dune is an analytics platform", "PunchSwap is a
+  Uniswap fork").
+- Generic protocol mechanics that are not integration-specific (how a Uniswap V2 `getAmountsOut` works).
+
+## The `verified:` date contract
+
+Every integration file header carries `verified: YYYY-MM-DD`. Treat it as the freshness stamp:
+
+- **Under 3 months old:** trust the file for structural facts. Still re-confirm any address the user
+  will transact against and any production endpoint.
+- **3 to 12 months old:** re-fetch endpoints, tool lists, and pricing before stating them. Structural
+  facts likely still hold.
+- **Over 12 months old:** treat the whole file as a lead, not a source. Re-verify capabilities,
+  endpoints, and addresses from canonical sources, and update the file's `verified:` date.
+
+When you re-verify a detail, update the integration file (the value and the `verified:` date) so the
+next session benefits. The registry should get more trustworthy with use.
+
+## The protocol
+
+1. **Identify the load-bearing integration facts** in your intended answer: the address, endpoint, tool,
+   capability, or number the builder will act on.
+2. **Check the integration file's `verified:` date** against the freshness contract above.
+3. **If a fetch is required,** hit the integration's canonical source named in the integration file (its
+   docs URL, its contracts page, its explorer), not a third-party aggregator and not search snippets.
+4. **State only confirmed facts,** and say where each came from (for example, "per Alchemy's Flow EVM
+   quickstart, fetched today", or "PunchSwap V2 Router per KittyPunch docs, verified 2026-06-23"). If
+   you could not confirm, say so and do not present the detail as current.
+
+## Failure mode this prevents
+
+A builder asks how to integrate a given tool. Claude gives a remembered endpoint or address. It has
+changed. The builder ships against a dead endpoint or sends funds to a wrong or old contract. Trust is
+destroyed, and funds may be lost.
+
+When the stakes are an address or a production endpoint, fetching is never the slow path. It is the only
+path.


### PR DESCRIPTION
## What & why

Introduces **`flow-ecosystem`** — a standardized, appendable system for incorporating **verified partner integrations** into the Flow AI Tools plugin, so that **Claude automatically routes a Flow builder to the right ecosystem tool at the moment of intent**, for the right use case, with verified instructions on how to call it.

The goal is a **scalable co-marketing surface**: a partner with a live MCP server, public API/SDK docs, or verified on-chain contracts becomes a registered integration once, and every builder using the plugin gets routed to them by *need* — not by browsing a directory.

## How it scales (add a partner without touching the router)

- **`SKILL.md`** — a thin, always-on router: need → integration → how to call it.
- **`references/routing-table.md`** — the need-to-integration index that *grows per partner* while the router stays small.
- **`references/integration-protocol.md`** — how to invoke each integration type: `mcp` / `docs` / `contract`.
- **`references/verification-gate.md`** — verify-before-claim for capabilities, endpoints, and (funds-bearing) contract addresses.
- **`references/ecosystem/_TEMPLATE.md`** — the schema every new integration fills. **Adding a partner = copy the template, add one routing-table row, append triggers to the description.**
- **`CONTRIBUTING.md`** — how a tool joins the ecosystem.

## Example integrations (illustrative, not consented partnerships)

Ships three `[example]` kits built from public docs to demonstrate each type: **Dune** (`mcp`), **Alchemy** (`docs`), **PunchSwap** (`contract`). All are explicitly marked `[example]` in the SKILL.md and routing table; each becomes a full entry only when the tool opts in.

## Also

- Registered in the `CLAUDE.md` Skill Routing Guide and the `README.md` plugin catalog.
- `claude plugin validate .` passes.